### PR TITLE
Migration to c17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,46 @@
 dist: xenial
+os: linux
 language: cpp
 compiler:
-- gcc
-os:
-- linux
+  - gcc
 
 jobs:
   include:
-    - stage: test
-      addons:
-        apt:
-          packages:
-            - flex
-            - bison
-            - make
-            - libboost-all-dev
-            - libgsl-dev
-            - ghc
-      install:
-        - ./configure
-        - make
-        - sudo make install
-      before_script:
-        # install missing ghc/haskell modules
-        - sudo apt-get install cabal-install -y
-        - cabal update
-        - cabal install random
-        # obtain truth data from secondary github repository
-        - git clone https://github.com/jlab/gapc-test-suite.git /home/travis/gapc-test-suite
-      script:
-        - make test-unit
-        - make test-paral
-        - make test-mod TRUTH_DIR=/home/travis/gapc-test-suite/Truth TRUTH_SUFFIX=_ubuntu
-        - make test-regress TRUTH_DIR=/home/travis/gapc-test-suite/Truth
-        - make test-ambiguity TRUTH_DIR=/home/travis/gapc-test-suite/Truth
+    - os: linux
+      dist: bionic # 18.04
+    - os: linux
+      dist: xenial # 16.04
+    # earlier distributions are lacking libgsl-dev AND are no longer supported by Ubuntu
+
+addons:
+  apt:
+    packages:
+      - flex
+      - bison
+      - make
+      - libboost-all-dev
+      - libgsl-dev
+      - ghc
+
+install:
+  - ./configure
+  - make
+  - sudo make install
+before_script:
+  # install missing ghc/haskell modules
+  - sudo apt-get install cabal-install -y
+  - cabal update
+  - cabal install random
+  # obtain truth data from secondary github repository
+  - git clone https://github.com/jlab/gapc-test-suite.git /home/travis/gapc-test-suite
+script:
+  # manually compiling an example to check for raised warnings ...
+  - cp testdata/grammar/elm.gap . && gapc -p "buyer * pretty2" elm.gap && make -f out.mf 2>&1 > /dev/null | tee make.stderr
+  # ... and test if "warning: dynamic exception specifications are deprecated" are no longer triggered
+  - test $(grep "warning:.dynamic exception specifications are deprecated" make.stderr -c) -eq 0
+  # run compiler test suite
+  - make test-unit
+  - make test-paral
+  - make test-mod TRUTH_DIR=/home/travis/gapc-test-suite/Truth TRUTH_SUFFIX=_ubuntu
+  - make test-regress TRUTH_DIR=/home/travis/gapc-test-suite/Truth
+  - make test-ambiguity TRUTH_DIR=/home/travis/gapc-test-suite/Truth

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.14.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/configure
+++ b/configure
@@ -686,6 +686,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -769,6 +770,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1021,6 +1023,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1158,7 +1169,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1311,6 +1322,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -4023,14 +4035,14 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++11" >&5
-$as_echo_n "checking whether C++ compiler accepts -std=c++11... " >&6; }
-if ${ax_cv_check_cxxflags___std_cpp11+:} false; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++17" >&5
+$as_echo_n "checking whether C++ compiler accepts -std=c++17... " >&6; }
+if ${ax_cv_check_cxxflags___std_cpp17+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
   ax_check_save_flags=$CXXFLAGS
-  CXXFLAGS="$CXXFLAGS  -std=c++11"
+  CXXFLAGS="$CXXFLAGS  -std=c++17"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -4043,18 +4055,18 @@ main ()
 }
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
-  ax_cv_check_cxxflags___std_cpp11=yes
+  ax_cv_check_cxxflags___std_cpp17=yes
 else
-  ax_cv_check_cxxflags___std_cpp11=no
+  ax_cv_check_cxxflags___std_cpp17=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   CXXFLAGS=$ax_check_save_flags
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___std_cpp11" >&5
-$as_echo "$ax_cv_check_cxxflags___std_cpp11" >&6; }
-if test "x$ax_cv_check_cxxflags___std_cpp11" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___std_cpp17" >&5
+$as_echo "$ax_cv_check_cxxflags___std_cpp17" >&6; }
+if test "x$ax_cv_check_cxxflags___std_cpp17" = xyes; then :
 
-  CXXFLAGS+=" -std=c++11"
+  CXXFLAGS+=" -std=c++17"
 
 else
   :
@@ -7624,14 +7636,4 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-
-
-
-
-
-
-
-
-
-
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,8 +62,8 @@ GAP_PIC_FLAGS
 
 
 AC_LANG([C++])
-AX_CHECK_COMPILE_FLAG([-std=c++11], [
-  CXXFLAGS+=" -std=c++11"
+AX_CHECK_COMPILE_FLAG([-std=c++17], [
+  CXXFLAGS+=" -std=c++17"
 ])
 
 ## test additional flags
@@ -94,7 +94,7 @@ if test "x$BISON" = "x"; then
 	echo "bison is needed to compile GapC."
 	exit -1
 fi
- 
+
 
 AC_PATH_PROG([HG], [hg])
 
@@ -145,13 +145,3 @@ AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memset strerror])
 
 AC_OUTPUT
-
-
-
-
-
-
-
-
-
-

--- a/documentation/developer_notes
+++ b/documentation/developer_notes
@@ -1,3 +1,13 @@
+2020-06-03 (Stefan Janssen):
+The configure script will gather your systems settings in order to setup correct environment variables for the make process.
+This script is generated itself, see: https://thoughtbot.com/blog/the-magic-behind-configure-make-make-install
+Thus, changes should be made in configure.ac instead of the generated configure file.
+We did so last, to migrate from c++11 to the newer c++17 standard. Following command were issued to update the configure script:
+  aclocal
+  autoconf
+  automake --add-missing
+(Note that the last command triggered warnings and errors. However, a working version of the configure script was generated)
+
 This file will give you an overview of the GAP-C project.
 If you have questions feel free contact me at: tgatter(at)cebitec.uni-bielefeld.de
 

--- a/rtlib/hashtng.hh
+++ b/rtlib/hashtng.hh
@@ -347,8 +347,8 @@ struct compare {
           inspector.finalize(*i);
       }
 
-      void *operator new(size_t t) throw (std::bad_alloc);
-      void operator delete(void *b) throw ();
+      void *operator new(size_t t) noexcept(false);
+      void operator delete(void *b) noexcept(false);
   };
 
 #define SET_TEMPLATE_DECL \
@@ -373,7 +373,7 @@ T, I, U, Hash_Policy, Resize_Policy, Shrink_Policy, Stat_Policy, load_factor
        Set_Dummy<SET_TEMPLATE_ARGS>::pool;
 
   template<SET_TEMPLATE_DECL>
-  void *Set<SET_TEMPLATE_ARGS>::operator new(size_t t) throw (std::bad_alloc)
+  void *Set<SET_TEMPLATE_ARGS>::operator new(size_t t) noexcept(false)
   {
     assert(sizeof(Set<SET_TEMPLATE_ARGS>) == t);
     Set<SET_TEMPLATE_ARGS> *r = Set_Dummy<SET_TEMPLATE_ARGS>::pool.malloc();
@@ -381,7 +381,7 @@ T, I, U, Hash_Policy, Resize_Policy, Shrink_Policy, Stat_Policy, load_factor
   }
 
   template<SET_TEMPLATE_DECL>
-  void Set<SET_TEMPLATE_ARGS>::operator delete(void *b) throw ()
+  void Set<SET_TEMPLATE_ARGS>::operator delete(void *b) noexcept(false)
   {
     if (!b)
       return;

--- a/rtlib/rope.hh
+++ b/rtlib/rope.hh
@@ -175,8 +175,8 @@ namespace rope {
         }
       }
 
-      void *operator new(size_t t) throw (std::bad_alloc);
-      void operator delete(void *b) throw ();
+      void *operator new(size_t t) noexcept(false);
+      void operator delete(void *b)noexcept(false);
 
   };
 
@@ -672,7 +672,7 @@ template<typename X>
 Pool<rope::Block<X> > rope::Ref<X>::pool;
 
 template<typename X>
-void *rope::Block<X>::operator new(size_t t) throw (std::bad_alloc)
+void *rope::Block<X>::operator new(size_t t) noexcept(false)
 {
   assert(t == sizeof(Block<X>));
   Block<X> *r = rope::Ref<X>::pool.malloc();
@@ -680,8 +680,10 @@ void *rope::Block<X>::operator new(size_t t) throw (std::bad_alloc)
 }
 
 template<typename X>
-void rope::Block<X>::operator delete(void *b) throw ()
+void rope::Block<X>::operator delete(void *b) noexcept(false)
 {
+
+
   if (!b)
     return;
   rope::Ref<X>::pool.free(static_cast<Block<X>*>(b));

--- a/rtlib/string.cc
+++ b/rtlib/string.cc
@@ -28,14 +28,14 @@
 // like in list?
 Pool<String::Block> String::pool;
 
-void *String::Block::operator new(size_t t) throw (std::bad_alloc)
+void *String::Block::operator new(size_t t) noexcept(false)
 {
   assert(t == sizeof(Block));
   Block *r = pool.malloc();
   return r;
 }
 
-void String::Block::operator delete(void *b) throw ()
+void String::Block::operator delete(void *b) noexcept(false)
 {
   if (!b)
     return;

--- a/rtlib/string.hh
+++ b/rtlib/string.hh
@@ -211,9 +211,9 @@ class String {
         array[pos++] = ((unsigned char *) &l)[3];
       }
 
-      void *operator new(size_t t) throw (std::bad_alloc);
+      void *operator new(size_t t) noexcept(false);
 
-      void operator delete(void *b) throw ();
+      void operator delete(void *b) noexcept(false);
 
       void put(std::ostream &s) const;
     };


### PR DESCRIPTION
Text from @sgtkellox :
C++17 does not need you to specify the exception type in a methods signature. All exception throwing methods have a tag noexcept(false) in the signature. Type specifications may still occure in the throw call when a exception causing error is detected.
https://en.cppreference.com/w/cpp/language/except_spec