### PR TITLE
checking if there is a dynamic exception spezification left

### DIFF
--- a/rtlib/string.cc
+++ b/rtlib/string.cc
@@ -27,7 +27,7 @@
 // FIXME instead of object pool interface use singleton pool interface
 // like in list?
 Pool<String::Block> String::pool;
-
+//has this signiture been altered?
 void *String::Block::operator new(size_t t) noexcept(false) {
   assert(t == sizeof(Block));
   Block *r = pool.malloc();


### PR DESCRIPTION
We need to check if this throws an error caused by a signature that is still using a dynamic exception specification.