### PR TITLE
sort generated code prior to diff

### DIFF
--- a/testdata/ambiguitytest/run.sh
+++ b/testdata/ambiguitytest/run.sh
@@ -185,7 +185,12 @@ cmp_ambigutiyErrors() {
 }
 
 cmp_specialization() {
-	log diff -u -w -B $1.gap $2/$1.gap
+	# generated code line positions are not stable, thus sort them first before comparison ... and clean up later
+	sort $1.gap > $1.sorted.gap.$$
+	sort $2/$1.gap > $2/$1.sorted.gap.$$
+	log diff -u -w -B $1.sorted.gap.$$ $2/$1.sorted.gap.$$
+	rm -f $1.sorted.gap.$$
+	rm -f $2/$1.sorted.gap.$$
 }
 
 


### PR DESCRIPTION
I saw OSX ambiguity tests failing, but when restarting the same code passed. I figure some tests are not stable to random effects. I guess it is test `specialization.test7Inst.baa.gap` and I am solving this by sorting the generated *.gap file prior to comparison against truth.