### PR TITLE
adding FLOAT terminal parser

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,43 @@
+bellmansgapc (2021.05.11-0ubuntu0ppa1~impish1) impish; urgency=medium
+
+   * added FLOAT terminal parser
+
+ -- janssenlab <stefan.m.janssen@gmail.com>  Tue, 11 May 2021 13:28:00 +0200
+
+bellmansgapc (2021.05.11-0ubuntu0ppa1~hirsute1) hirsute; urgency=medium
+
+   * added FLOAT terminal parser
+
+ -- janssenlab <stefan.m.janssen@gmail.com>  Tue, 11 May 2021 13:28:00 +0200
+
+bellmansgapc (2021.05.11-0ubuntu0ppa1~groovy1) groovy; urgency=medium
+
+   * added FLOAT terminal parser
+
+ -- janssenlab <stefan.m.janssen@gmail.com>  Tue, 11 May 2021 13:28:00 +0200
+
+bellmansgapc (2021.05.11-0ubuntu0ppa1~focal1) focal; urgency=medium
+
+   * added FLOAT terminal parser
+
+ -- janssenlab <stefan.m.janssen@gmail.com>  Tue, 11 May 2021 13:28:00 +0200
+
+bellmansgapc (2021.05.11-0ubuntu0ppa1~bionic1) bionic; urgency=medium
+
+   * added FLOAT terminal parser
+
+ -- janssenlab <stefan.m.janssen@gmail.com>  Tue, 11 May 2021 13:28:00 +0200
+
+bellmansgapc (2021.05.11-0ubuntu0ppa1~xenial1) xenial; urgency=medium
+
+   * added FLOAT terminal parser
+
+ -- janssenlab <stefan.m.janssen@gmail.com>  Tue, 11 May 2021 13:28:00 +0200
+
 bellmansgapc (2021.04.28-0ubuntu0ppa1~impish1) impish; urgency=medium
 
   * added test_macrostate_mme_assumption to librna to warn about macrostate energy inaccuracies
-  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20. 
+  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20.
     * Thanks for raising awareness go to Vincent von Schelm and for pointing out the difference to Ronny Lorenz!
   * gapc with -l 1 will now report table design and estimated runtime
 
@@ -10,7 +46,7 @@ bellmansgapc (2021.04.28-0ubuntu0ppa1~impish1) impish; urgency=medium
 bellmansgapc (2021.04.28-0ubuntu0ppa1~hirsute1) hirsute; urgency=low
 
   * added test_macrostate_mme_assumption to librna to warn about macrostate energy inaccuracies
-  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20. 
+  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20.
     * Thanks for raising awareness go to Vincent von Schelm and for pointing out the difference to Ronny Lorenz!
   * gapc with -l 1 will now report table design and estimated runtime
 
@@ -19,7 +55,7 @@ bellmansgapc (2021.04.28-0ubuntu0ppa1~hirsute1) hirsute; urgency=low
 bellmansgapc (2021.04.28-0ubuntu0ppa1~groovy1) groovy; urgency=medium
 
   * added test_macrostate_mme_assumption to librna to warn about macrostate energy inaccuracies
-  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20. 
+  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20.
     * Thanks for raising awareness go to Vincent von Schelm and for pointing out the difference to Ronny Lorenz!
   * gapc with -l 1 will now report table design and estimated runtime
 
@@ -28,7 +64,7 @@ bellmansgapc (2021.04.28-0ubuntu0ppa1~groovy1) groovy; urgency=medium
 bellmansgapc (2021.04.28-0ubuntu0ppa1~focal1) focal; urgency=medium
 
   * added test_macrostate_mme_assumption to librna to warn about macrostate energy inaccuracies
-  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20. 
+  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20.
     * Thanks for raising awareness go to Vincent von Schelm and for pointing out the difference to Ronny Lorenz!
   * gapc with -l 1 will now report table design and estimated runtime
 
@@ -37,7 +73,7 @@ bellmansgapc (2021.04.28-0ubuntu0ppa1~focal1) focal; urgency=medium
 bellmansgapc (2021.04.28-0ubuntu0ppa1~bionic1) bionic; urgency=medium
 
   * added test_macrostate_mme_assumption to librna to warn about macrostate energy inaccuracies
-  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20. 
+  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20.
     * Thanks for raising awareness go to Vincent von Schelm and for pointing out the difference to Ronny Lorenz!
   * gapc with -l 1 will now report table design and estimated runtime
 
@@ -46,7 +82,7 @@ bellmansgapc (2021.04.28-0ubuntu0ppa1~bionic1) bionic; urgency=medium
 bellmansgapc (2021.04.28-0ubuntu0ppa1~xenial1) xenial; urgency=medium
 
   * added test_macrostate_mme_assumption to librna to warn about macrostate energy inaccuracies
-  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20. 
+  * applied old fix to energy parameters from ViennaRNA, see https://github.com/jlab/fold-grammars/issues/20.
     * Thanks for raising awareness go to Vincent von Schelm and for pointing out the difference to Ronny Lorenz!
   * gapc with -l 1 will now report table design and estimated runtime
 

--- a/rtlib/terminal.hh
+++ b/rtlib/terminal.hh
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <cstring>
 #include <limits>
+#include <cmath>
 
 #include "empty.hh"
 #include "string.hh"
@@ -74,6 +75,38 @@ inline int INT(Sequence &seq, pos_type i, pos_type j) {
     }
     result = result * 10 + (seq[a] - '0');
   }
+  return result;
+}
+
+template<typename pos_type>
+inline float FLOAT(Sequence &seq, pos_type i, pos_type j) {
+  assert(i < j);
+  float result = 0;
+  bool saw_exponent = false;
+  int exponent = 0;
+
+  // iterate through characters and return empty if char is neither . nor digit
+  // if char is '.': start incrementing the exponent, i.e. count the number
+  // of digits right of '.' and skip increasing result for now
+  for (pos_type a = i; a < j; a++) {
+    if (seq[a] == '.') {
+      saw_exponent = true;
+    } else {
+      if (seq[a] < '0' || seq[a] > '9') {
+        float r;
+        empty(r);
+        return r;
+      }
+      if (saw_exponent) {
+        ++exponent;
+      }
+      result = result * 10 + (seq[a] - '0');
+    }
+  }
+  
+  // after all digits have been parsed and combined in one large int value
+  // devide result by 10^exponent to get real float
+  result = result / pow(10, exponent);
   return result;
 }
 

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -53,6 +53,13 @@ void Terminal::add_predefined(Grammar &grammar) {
   t->setPredefinedTerminalParser(true);
   grammar.NTs[*(t->name)] = t;
 
+  s = new std::string("FLOAT");
+  t = new Symbol::Terminal(s, l);
+  t->writeable_ys().set(1, Yield::UP);
+  t->set_data_type(new Type::Float());
+  t->setPredefinedTerminalParser(true);
+  grammar.NTs[*(t->name)] = t;
+
   s = new std::string("STRING");
   t = new Symbol::Terminal(s, l);
   t->writeable_ys().set(0, Yield::UP);

--- a/testdata/grammar/testfloat.gap
+++ b/testdata/grammar/testfloat.gap
@@ -1,0 +1,28 @@
+signature sig_bst(alphabet, answer) {
+  answer keypair(float);
+  answer tcase(int);
+  choice [answer] h([answer]);
+}
+
+algebra alg_enum auto enum;
+algebra alg_count auto count;
+
+algebra alg_test implements sig_bst(alphabet=char, answer=float) {
+  float keypair(float x) {
+    return x;
+  }
+  float tcase(int y) {
+    return y;
+  }
+  choice [float] h([float] candidates) {
+    return candidates;
+  }
+
+}
+
+grammar gra_bst uses sig_bst(axiom = entry) {
+  entry = keypair(FLOAT) | tcase(INT) # h;
+}
+
+//~ instance enum = gra_bst(alg_test);
+instance enum = gra_bst(alg_enum * alg_test);

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -419,6 +419,8 @@ GAPC="../../../gapc --subopt"
 check_new_old_eq rnashapesmfe.gap unused mfeppshape "A" foo
 
 #test new FLOAT terminal parser
+GAPC="../../../gapc"
+RUN_CPP_FLAGS=""
 check_new_old_eq testfloat.gap unused enum "23" floatint
 check_new_old_eq testfloat.gap unused enum "23.4" justfloat
 check_new_old_eq testfloat.gap unused enum "23.45" largerfloat

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -3,417 +3,425 @@ DEFAULT_LDLIBS_EXTRA=$LDLIBS_EXTRA
 DEFAULT_CPPFLAGS_EXTRA=$CPPFLAGS_EXTRA
 DEFAULT_GAPC=$GAPC
 
-check_new_old_eq elm.gap unused enum 1+2*3*4+5 foo
-
-check_new_old_eq loco3stem.gap unused count caucguacgucagucguagucaguugcagugcaucgacua foo
-
-check_new_old_eq loco3stem.gap unused count gggcguucucauagguccgcguggguuagacauucaagguuauuuuuuauccggaguuaccucaucuaauugauagauuaagaaauucuuuuguucgaauaaggcgcaguuauuuacccuuuugauuccuaaaaacuuuccgccgccgucaagaugacaaauaacaaacuugccaaggcggcauccguuuuuagauaauu bar
-
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq rnashapes2wip.gap unused mfepp gcgcggugcgucacgcaucacauacucaucaacgaugagaagc foo
-
-check_new_old_eq rnashapespf.gap unused pf GGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCUGGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCU pf
-
-RUN_CPP_FLAGS=""
-
-check_new_old_eq cmsmallint.gap unused enum a foo
-
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq adpf.gap unused shapemfepp acgugucagucagucauggucaucauacugccgua foo
-
-CPPFLAGS_EXTRA+="-DSTATS"
-
-# FIXME, with optimized classify, the stat-ing of one hash-table is of no use
-# ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagugcagcgauugacggauucagucggggcauauugugcauaaugucagc
-#check_feature adpf.gap shape5 ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagug foo err grep "Hi water use: 428785\>"
-
-CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
-
-GAPC="../../../gapc -t --window-mode"
-
-RUN_CPP_FLAGS="-w 20 -i 5"
-
-check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug foo
-
-RUN_CPP_FLAGS="-w 23 -i 8"
-
-check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug bar
-
-RUN_CPP_FLAGS="-w 100 -i 50 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq adpf.gap unused mfepp cuccccucuucggacgcaacuuaugccuaggaccuauuuugcacagaaugagggcuagggaagagccgucccucagugagcagaguuaaguuguuguuugaguaacucccggcgggcuaagccauugcacccaaccgcuugccugucauucuggaccgggauggaaccguaccucugcacuuaagacagacuaucaaaagcguauggcggguuguggucucaagugggaggacaaucaccguauauuugaucaacgauucagggaugcucacccguuucuuauuugaaacuuggcacccggaauauucugaagccaauacaguuugugacacaaccccgucaguugagacucuuuuaacgccgugugccgacgaaucuccccacgguaugcgcuggucggucccacgagggcguauaucgccaaggcagcuuaugguaacgucgcauaccagcucaagccgguugaaauaacagguccaguuuguaggucucuucugugacguaggccugcagcaagaacugcgcaugcuugucguagaggccaauagagcugaucuggcaaucguaaagguaguguuuagguagcuucauguauucaucuuucgucaucgcaagcuaaacuugcgcucaucacuauggcgucaucugaggucguugcgagaaagaugcuagguugcgcgcauaacgacuuuaagcguuagauuccgccucucaucgggccagcgaaagacccauacgcaaacgcgcuaucgcaguaauggaauaauuggcaguacucaucgccggcgucgcuauguucuaugcucacgcucucuccaggcggcggauggucccugccagcgcucgagaggcauccaaguuggaacuauauccuaugaaucacaaugccggucacuucgcgggcuaauaaguuccucaggggaccaggacgugauuuuccgugcagggggggccggucacacgcaggagguuugggcuagcacaagcccaacaaccacau foo
-
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-f"
-
-check_new_old_eq adpf.gap unused shape5 "../../input/rna127" bar 
-
-RUN_CPP_FLAGS=""
-CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
-# under Linux -lgmpxx pulls automatically -lgmp, Solaris does not
-LDLIBS_EXTRA+=" -lgmp -lgmpxx"
-
-check_new_old_eq elm.gap unused acount '1+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+1' foo
-
-CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
-LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
-
-# Jens subopt old adpc bug report 1
-
-GAPC="../../../gapc -t --subopt"
-
-# 30 %
-RUN_CPP_FLAGS="-d 552 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt30
-
-# 31 %
-GAPC="../../../gapc -t --cyk --subopt"
-RUN_CPP_FLAGS="-d 570 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt31
-
-# Jens subopt old adpc bug report 2 (prob sum > 1.0)
-
-GAPC="../../../gapc -t --subopt"
-RUN_CPP_FLAGS="-d 1090 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq adpf_nonamb.gap unused mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA subopt
-
-check_feature adpf_nonamb.gap mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA suboptpfsum out $KSH ../check_prob_sum 9.33773
-
+#check_new_old_eq elm.gap unused enum 1+2*3*4+5 foo
 #
-
-# another Jens subopt RNAshapes -r -s  Probability sum > 1.0 bug
-# mail from Date: Fri, 13 Feb 2009 11:16:32 
-
-RUN_CPP_FLAGS="-d 224 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_feature adpf_nonamb.gap mfepppf UCACCGUCGGAAAGUGUGCGCUUUCCCUGAUGAGCCCAAAAGGGCGAAACGGUAC suboptpfsum2 out $KSH ../check_prob_sum 5.06405e+08
-
+#check_new_old_eq loco3stem.gap unused count caucguacgucagucguagucaguugcagugcaucgacua foo
 #
-
-GAPC="../../../gapc -t"
-
-check_new_old_eq adpf_nonamb.gap unused shape5pf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA shapesubopt
-
-GAPC="../../../gapc --tab-all"
-RUN_CPP_FLAGS="-f"
-
-# FIXME remove - obsoleted by external test case, which is more robust
-#check_new_old_eq adpf_nonamb.gap unused shape5pfx ../../input/rna150 shapefpffilter
-
-
-#GSL_RNG_SEED=`../rand 1`
-#export GSL_RNG_SEED
-
-RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par -f"
-GAPC="../../../gapc -t --sample"
-
-check_feature adpf.gap pfsampleshape ../../input/rna100 sample out $KSH ../check_samples ../adpf.rna100shapepf 0.000349275 0.00005
-
-
-# Sequence from Jens RNAshapes sampling mode bug report
-
-RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_feature adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample out $KSH ../check_samples ../nonamb_shape_pf.log 6.33459e-05 0.00005
-
-# Sequence from Jens RNAshapes sampling mode bug report, distribution test
-
-RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
-
-check_feature_repeat_mean_var adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample2
-
-# Too much sample output bug ( see a9fed4287fda and 980a3871b4a7 )
-GAPC="../../../gapc -t --sample --cyk"
-RUN_CPP_FLAGS="-r 1 -P ../../../librna/vienna/rna_turner1999.par -f"
-check_feature adpf_nonamb.gap pfsampleshapeall ../../input/rna400 samplecount out $KSH ../check_sample_count
-
-RUN_CPP_FLAGS="-f"
-GAPC="../../../gapc -t"
-
-check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeone
-
-CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
-LDLIBS_EXTRA+=" -lgmp -lgmpxx"
-
-check_new_old_eq adpf.gap unused cart ../../input/rna150 cartesian
-
-GAPC="../../../gapc -t --backtrack"
-
-check_new_old_eq adpf.gap unused cartpp2 ../../input/rna20 cartesian2
-
-CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
-LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
-
-RUN_CPP_FLAGS="-f"
-GAPC="../../../gapc -t --backtrack"
-
-check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeonebt
-
-GAPC="../../../gapc -t --kbacktrack"
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq adpf_nonamb.gap unused shapemfepf acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbt
-
-# FIXME remove - obsoleted by external test case, which is more robust
-#check_new_old_eq adpf_nonamb.gap unused shapemfepfx acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbtpfx
-
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
-GAPC="../../../gapc -t --cyk --kbacktrack"
-
-check_new_old_eq helene.gap unused mfepp ../../input/rna100 rope
-
-
-check_external extpfx ../check_shape_filter_old_new "../../test/shapemfepfx/main -w 2 -i 1 -P ../../../librna/vienna/rna_turner1999.par" $REF/shapemfepfx.150.log 0.000001 0.000001 2 `cat ../../input/rna150`
-
-check_external extsample ../check_shape_filter "../../test/shrepmfesample/main -r 2000 -P ../../../librna/vienna/rna_turner1999.par" $REF/shrepmfesample.2000.150.log 0.0002 0.0002 1 `cat ../../input/rna150`
-
-
-check_external extpfxwindow ../../test/shapemfepfx/test.pl ../../test/shapemfepfx/main ../../test/shapemfepfx/nowindow `cat ../../input/rna100`
-
-
-#RUN_CPP_FLAGS="-x -300 -f"
-# thresh of 0
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
-GAPC="../../../gapc -t --kbacktrack --cyk"
-
-check_new_old_eq adpf_hl.gap unused mfepp ../../input/rna200 suchthat
-
-
-GAPC="../../../gapc -t --cyk --subopt-classify --kbacktrack"
-RUN_CPP_FLAGS="-d 0 -P ../../../librna/vienna/rna_turner1999.par -f"
-
-check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape
-
-RUN_CPP_FLAGS="-d 50 -P ../../../librna/vienna/rna_turner1999.par -f"
-check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape2
-
-RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
-check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape3
-
-RUN_CPP_FLAGS="-d 429 -P ../../../librna/vienna/rna_turner1999.par -f"
-check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape4
-
-RUN_CPP_FLAGS="-d 430 -P ../../../librna/vienna/rna_turner1999.par -f"
-check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape5
-
-RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
-check_new_old_eq adpf_nonamb.gap unused shapemfepp ../../input/rna80 subshape8
-
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
-GAPC="../../../gapc -t --cyk --kbacktrack"
-check_new_old_eq adpf.gap unused shapemfeppcl ../../input/rna20 subshape6
-
-check_new_old_eq adpf.gap unused shapemfeppshcl ../../input/rna20 subshape7
-
-RUN_CPP_FLAGS=""
-
-
-# FIXME tab heuristic (-t) is not optimal for this grammar
-GAPC="../../../gapc --tab-all"
-check_new_old_eq structure2shape.gap unused shape5 '..(((...((......))...(((.....)))....)))..' structure
-
-
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-f"
-check_new_old_eq flowgram.gap unused foo ../../input/flow  flow
-
-RUN_CPP_FLAGS="-w 20 -i 5 -P ../../../librna/vienna/rna_turner1999.par -f"
-GAPC="../../../gapc -t --backtrack --window-mode"
-check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowbacktrack
-
-RUN_CPP_FLAGS="-w 20 -i 1 -P ../../../librna/vienna/rna_turner1999.par -f"
-GAPC="../../../gapc -t --kbacktrack --no-coopt --window-mode"
-check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowkbacktrack
-
-RUN_CPP_FLAGS=""
-GAPC="../../../gapc -t"
-check_new_old_eq g3pl.gap unused shapeprobls acgucguagucagucaacguacgucagu classlogspace
-
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-f"
-check_new_old_eq flowgram2b.gap unused score ../../input/flow.2  multitrack.flow
-
-GAPC="../../../gapc -t --cyk --kbacktrack"
-check_new_old_eq flowgram2b.gap unused foo ../../input/flow.2  multitrack.flow
-
-
-# multiple singleton {} blocks in grammar (see nt_stem)
-
-RUN_CPP_FLAGS=""
-GAPC="../../../gapc -t"
-
-check_new_old_eq single_block.gap unused count CCAAAGG block
-
-check_new_old_eq elm.gap unused enumenum '1+2*3' prodcopy
-
-check_new_old_eq optimalMCM.gap unused minmemminmult '[3x4]*[4x3]' extends
-
-
-# test case for multiple classifying choice fns -> classify optimization
-# minimal example for part of the pknotsRG multi choice fns classify bug
-check_new_old_eq mchoice.gap unused shape 'gattaca' multiplechoiceclass
-
-# FIXME add pknotsRG shape5
-
-GAPC="../../../gapc -t --cyk --kbacktrack"
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq pknotsRG.gap unused mfepp 'acgucgaaauaaaugccuugucugcuauauucgacgcgagcuuaauauuuggggcc' index
-
-
-GAPC="../../../gapc -t "
-
-check_new_old_eq tdm2hp.gap unused pretty aaacccggggaauuccuu tabledim
-check_new_old_eq tdm2hporig.gap unused pf gaauacccacggaugguagauuucgcuuuugggugaacuugccacgcccccgacggucgcgagcuuaucugcuauaccccaauugagaauacagggaacuu tabledim
-
-
-GAPC="../../../gapc -t --kbacktrace --no-coopt"
-RUN_CPP_FLAGS=""
-
-check_new_old_eq nussinov2.gap unused bpmaxpp caguagucagcu nocooptkbt
-
-GAPC="../../../gapc -t --kbacktrace "
-RUN_CPP_FLAGS=" gggaaaaccc "
-
-check_new_old_eq multfilter.gap unused bpmaxpp aggaaaacca multitrack.filter
-
-GAPC="../../../gapc -t  "
-RUN_CPP_FLAGS=" cagu "
-
-check_new_old_eq aliglob2.gap unused enum cag multitrack.enum
-
-
-RUN_CPP_FLAGS=""
-
-check_compiler_output ../../grammar2 elmnoterm.gap buyer compile grep "Function char is not defined"
-
-GAPC="../../../gapc -t  "
-RUN_CPP_FLAGS=""
-GRAMMAR=../../grammar2
-
-check_new_old_eq multigrammar.gap unused seller '1+2*3*4+5' multigrammar
-
-check_new_old_eq ochoice.gap unused buyer '1+2*3*4+5' optchoice
-
-
-GAPC="../../../gapc --tab-all  "
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-GRAMMAR=../../grammar2
-
-check_new_old_eq p7.gap unused mfe 'gagacugcagucc' tablegen
-check_new_old_eq p72.gap unused mfe 'gagacugcagucc' tablegen
-
-GAPC="../../../gapc --tab-all --cyk --kbacktrace"
-GRAMMAR=../../grammar2
-RUN_CPP_FLAGS=""
-
-check_new_old_eq rf01380.gap unused cykpp 'AGUCA' tablegen.rightlin
-
-GAPC="../../../gapc -t --kbest"
-RUN_CPP_FLAGS="-k 5 -P ../../../librna/vienna/rna_turner1999.par -f"
-GRAMMAR=../../grammar
-
-check_new_old_eq adpf.gap unused shapemfe ../../input/rna200 kbest
-
-
-GAPC="../../../gapc --tab-all"
-RUN_CPP_FLAGS="AA "
-GRAMMAR=../../grammar2
-check_new_old_eq menum.gap unused enumi "AA" multi.enum
-
-
-RUN_CPP_FLAGS=""
-GAPC="../../../gapc -t "
-GRAMMAR=../../grammar2
-
-check_compiler_output ../../grammar2 ttcounterr.gap test compile.multi grep "does not match"
-
-GRAMMAR=../../grammar
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-
-check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t1999
-check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t1999
-check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t1999
-
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner2004.par"
-
-check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t2004
-check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t2004
-check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t2004
-
-
-RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner1999.par"
-
-GAPC="../../../gapc -t"
-
-check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t1999
-check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t1999
-check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t1999
-
-GAPC="../../../gapc -t"
-RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner2004.par"
-
-check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t2004
-check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t2004
-check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t2004
-
-RUN_CPP_FLAGS="-f"
-GRAMMAR=../../grammar2
-GAPC="../../../gapc -t"
-
-check_new_old_eq escape.gap unused acount ../../input/esc esc
-
-RUN_CPP_FLAGS="c"
-GRAMMAR=../../grammar2
-GAPC="../../../gapc -t --kbacktrace"
-
-# from mmoehl
-check_new_old_eq interaction.gap unused bpmaxpp g multitrack.kbt
-
-GAPC="../../../gapc -t "
-GRAMMAR=../../grammar2
-RUN_CPP_FLAGS="abc"
-
-check_new_old_eq mcount.gap unused cnt abc multitrack.count
-
-RUN_CPP_FLAGS="ac"
-
-check_new_old_eq trackpos.gap unused cnt dc multitrack.trackpos
-
-GRAMMAR=../../grammar2
-RUN_CPP_FLAGS=""
-
-check_new_old_eq overlay.gap unused count '1+2*3*4*5' overlay
-
-GAPC="../../../gapc -t --kbacktrace"
-RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-check_new_old_eq backtraceminys.gap unused  mfepre a kbt
-
-GAPC="../../../gapc -t --cyk"
-RUN_CPP_FLAGS=""
-
-GRAMMAR=../../grammar2
-
-check_new_old_eq adpfiupac.gap unused mfepp agcugucaugcagucguagucaguca iupac
-
-GRAMMAR=../../grammar2
-check_new_old_eq locomotif.gap unused pretty acugacugaacuguacguugaugac foo
-
-#test for new functions to rope: "front", "back" and "tail". For MacOSx the shape datatype has problems with hashing, thus we need a rope version for the shape algebras, but that rope first has to implement the aforementioned functions.
-GRAMMAR=../../grammar
-GAPC="../../../gapc"
-check_new_old_eq macrostate.gap unused shape1count acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc shape_t
-check_new_old_eq macrostate.gap unused shape1ropecount acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc rope
-
-# we are here testing of seg fault due to wrongly increased Iterator in hashmap (subopt.cc) passes
-# See issue #38 @ github.com/jlab/gapc
-GAPC="../../../gapc --subopt"
-check_new_old_eq rnashapesmfe.gap unused mfeppshape "A" foo
+#check_new_old_eq loco3stem.gap unused count gggcguucucauagguccgcguggguuagacauucaagguuauuuuuuauccggaguuaccucaucuaauugauagauuaagaaauucuuuuguucgaauaaggcgcaguuauuuacccuuuugauuccuaaaaacuuuccgccgccgucaagaugacaaauaacaaacuugccaaggcggcauccguuuuuagauaauu bar
+#
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq rnashapes2wip.gap unused mfepp gcgcggugcgucacgcaucacauacucaucaacgaugagaagc foo
+#
+#check_new_old_eq rnashapespf.gap unused pf GGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCUGGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCU pf
+#
+#RUN_CPP_FLAGS=""
+#
+#check_new_old_eq cmsmallint.gap unused enum a foo
+#
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq adpf.gap unused shapemfepp acgugucagucagucauggucaucauacugccgua foo
+#
+#CPPFLAGS_EXTRA+="-DSTATS"
+#
+## FIXME, with optimized classify, the stat-ing of one hash-table is of no use
+## ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagugcagcgauugacggauucagucggggcauauugugcauaaugucagc
+##check_feature adpf.gap shape5 ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagug foo err grep "Hi water use: 428785\>"
+#
+#CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
+#
+#GAPC="../../../gapc -t --window-mode"
+#
+#RUN_CPP_FLAGS="-w 20 -i 5"
+#
+#check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug foo
+#
+#RUN_CPP_FLAGS="-w 23 -i 8"
+#
+#check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug bar
+#
+#RUN_CPP_FLAGS="-w 100 -i 50 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq adpf.gap unused mfepp cuccccucuucggacgcaacuuaugccuaggaccuauuuugcacagaaugagggcuagggaagagccgucccucagugagcagaguuaaguuguuguuugaguaacucccggcgggcuaagccauugcacccaaccgcuugccugucauucuggaccgggauggaaccguaccucugcacuuaagacagacuaucaaaagcguauggcggguuguggucucaagugggaggacaaucaccguauauuugaucaacgauucagggaugcucacccguuucuuauuugaaacuuggcacccggaauauucugaagccaauacaguuugugacacaaccccgucaguugagacucuuuuaacgccgugugccgacgaaucuccccacgguaugcgcuggucggucccacgagggcguauaucgccaaggcagcuuaugguaacgucgcauaccagcucaagccgguugaaauaacagguccaguuuguaggucucuucugugacguaggccugcagcaagaacugcgcaugcuugucguagaggccaauagagcugaucuggcaaucguaaagguaguguuuagguagcuucauguauucaucuuucgucaucgcaagcuaaacuugcgcucaucacuauggcgucaucugaggucguugcgagaaagaugcuagguugcgcgcauaacgacuuuaagcguuagauuccgccucucaucgggccagcgaaagacccauacgcaaacgcgcuaucgcaguaauggaauaauuggcaguacucaucgccggcgucgcuauguucuaugcucacgcucucuccaggcggcggauggucccugccagcgcucgagaggcauccaaguuggaacuauauccuaugaaucacaaugccggucacuucgcgggcuaauaaguuccucaggggaccaggacgugauuuuccgugcagggggggccggucacacgcaggagguuugggcuagcacaagcccaacaaccacau foo
+#
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-f"
+#
+#check_new_old_eq adpf.gap unused shape5 "../../input/rna127" bar 
+#
+#RUN_CPP_FLAGS=""
+#CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
+## under Linux -lgmpxx pulls automatically -lgmp, Solaris does not
+#LDLIBS_EXTRA+=" -lgmp -lgmpxx"
+#
+#check_new_old_eq elm.gap unused acount '1+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+1' foo
+#
+#CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
+#LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
+#
+## Jens subopt old adpc bug report 1
+#
+#GAPC="../../../gapc -t --subopt"
+#
+## 30 %
+#RUN_CPP_FLAGS="-d 552 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt30
+#
+## 31 %
+#GAPC="../../../gapc -t --cyk --subopt"
+#RUN_CPP_FLAGS="-d 570 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt31
+#
+## Jens subopt old adpc bug report 2 (prob sum > 1.0)
+#
+#GAPC="../../../gapc -t --subopt"
+#RUN_CPP_FLAGS="-d 1090 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq adpf_nonamb.gap unused mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA subopt
+#
+#check_feature adpf_nonamb.gap mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA suboptpfsum out $KSH ../check_prob_sum 9.33773
+#
+##
+#
+## another Jens subopt RNAshapes -r -s  Probability sum > 1.0 bug
+## mail from Date: Fri, 13 Feb 2009 11:16:32 
+#
+#RUN_CPP_FLAGS="-d 224 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_feature adpf_nonamb.gap mfepppf UCACCGUCGGAAAGUGUGCGCUUUCCCUGAUGAGCCCAAAAGGGCGAAACGGUAC suboptpfsum2 out $KSH ../check_prob_sum 5.06405e+08
+#
+##
+#
+#GAPC="../../../gapc -t"
+#
+#check_new_old_eq adpf_nonamb.gap unused shape5pf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA shapesubopt
+#
+#GAPC="../../../gapc --tab-all"
+#RUN_CPP_FLAGS="-f"
+#
+## FIXME remove - obsoleted by external test case, which is more robust
+##check_new_old_eq adpf_nonamb.gap unused shape5pfx ../../input/rna150 shapefpffilter
+#
+#
+##GSL_RNG_SEED=`../rand 1`
+##export GSL_RNG_SEED
+#
+#RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par -f"
+#GAPC="../../../gapc -t --sample"
+#
+#check_feature adpf.gap pfsampleshape ../../input/rna100 sample out $KSH ../check_samples ../adpf.rna100shapepf 0.000349275 0.00005
+#
+#
+## Sequence from Jens RNAshapes sampling mode bug report
+#
+#RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_feature adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample out $KSH ../check_samples ../nonamb_shape_pf.log 6.33459e-05 0.00005
+#
+## Sequence from Jens RNAshapes sampling mode bug report, distribution test
+#
+#RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_feature_repeat_mean_var adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample2
+#
+## Too much sample output bug ( see a9fed4287fda and 980a3871b4a7 )
+#GAPC="../../../gapc -t --sample --cyk"
+#RUN_CPP_FLAGS="-r 1 -P ../../../librna/vienna/rna_turner1999.par -f"
+#check_feature adpf_nonamb.gap pfsampleshapeall ../../input/rna400 samplecount out $KSH ../check_sample_count
+#
+#RUN_CPP_FLAGS="-f"
+#GAPC="../../../gapc -t"
+#
+#check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeone
+#
+#CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
+#LDLIBS_EXTRA+=" -lgmp -lgmpxx"
+#
+#check_new_old_eq adpf.gap unused cart ../../input/rna150 cartesian
+#
+#GAPC="../../../gapc -t --backtrack"
+#
+#check_new_old_eq adpf.gap unused cartpp2 ../../input/rna20 cartesian2
+#
+#CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
+#LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
+#
+#RUN_CPP_FLAGS="-f"
+#GAPC="../../../gapc -t --backtrack"
+#
+#check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeonebt
+#
+#GAPC="../../../gapc -t --kbacktrack"
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq adpf_nonamb.gap unused shapemfepf acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbt
+#
+## FIXME remove - obsoleted by external test case, which is more robust
+##check_new_old_eq adpf_nonamb.gap unused shapemfepfx acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbtpfx
+#
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
+#GAPC="../../../gapc -t --cyk --kbacktrack"
+#
+#check_new_old_eq helene.gap unused mfepp ../../input/rna100 rope
+#
+#
+#check_external extpfx ../check_shape_filter_old_new "../../test/shapemfepfx/main -w 2 -i 1 -P ../../../librna/vienna/rna_turner1999.par" $REF/shapemfepfx.150.log 0.000001 0.000001 2 `cat ../../input/rna150`
+#
+#check_external extsample ../check_shape_filter "../../test/shrepmfesample/main -r 2000 -P ../../../librna/vienna/rna_turner1999.par" $REF/shrepmfesample.2000.150.log 0.0002 0.0002 1 `cat ../../input/rna150`
+#
+#
+#check_external extpfxwindow ../../test/shapemfepfx/test.pl ../../test/shapemfepfx/main ../../test/shapemfepfx/nowindow `cat ../../input/rna100`
+#
+#
+##RUN_CPP_FLAGS="-x -300 -f"
+## thresh of 0
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
+#GAPC="../../../gapc -t --kbacktrack --cyk"
+#
+#check_new_old_eq adpf_hl.gap unused mfepp ../../input/rna200 suchthat
+#
+#
+#GAPC="../../../gapc -t --cyk --subopt-classify --kbacktrack"
+#RUN_CPP_FLAGS="-d 0 -P ../../../librna/vienna/rna_turner1999.par -f"
+#
+#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape
+#
+#RUN_CPP_FLAGS="-d 50 -P ../../../librna/vienna/rna_turner1999.par -f"
+#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape2
+#
+#RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
+#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape3
+#
+#RUN_CPP_FLAGS="-d 429 -P ../../../librna/vienna/rna_turner1999.par -f"
+#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape4
+#
+#RUN_CPP_FLAGS="-d 430 -P ../../../librna/vienna/rna_turner1999.par -f"
+#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape5
+#
+#RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
+#check_new_old_eq adpf_nonamb.gap unused shapemfepp ../../input/rna80 subshape8
+#
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
+#GAPC="../../../gapc -t --cyk --kbacktrack"
+#check_new_old_eq adpf.gap unused shapemfeppcl ../../input/rna20 subshape6
+#
+#check_new_old_eq adpf.gap unused shapemfeppshcl ../../input/rna20 subshape7
+#
+#RUN_CPP_FLAGS=""
+#
+#
+## FIXME tab heuristic (-t) is not optimal for this grammar
+#GAPC="../../../gapc --tab-all"
+#check_new_old_eq structure2shape.gap unused shape5 '..(((...((......))...(((.....)))....)))..' structure
+#
+#
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-f"
+#check_new_old_eq flowgram.gap unused foo ../../input/flow  flow
+#
+#RUN_CPP_FLAGS="-w 20 -i 5 -P ../../../librna/vienna/rna_turner1999.par -f"
+#GAPC="../../../gapc -t --backtrack --window-mode"
+#check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowbacktrack
+#
+#RUN_CPP_FLAGS="-w 20 -i 1 -P ../../../librna/vienna/rna_turner1999.par -f"
+#GAPC="../../../gapc -t --kbacktrack --no-coopt --window-mode"
+#check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowkbacktrack
+#
+#RUN_CPP_FLAGS=""
+#GAPC="../../../gapc -t"
+#check_new_old_eq g3pl.gap unused shapeprobls acgucguagucagucaacguacgucagu classlogspace
+#
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-f"
+#check_new_old_eq flowgram2b.gap unused score ../../input/flow.2  multitrack.flow
+#
+#GAPC="../../../gapc -t --cyk --kbacktrack"
+#check_new_old_eq flowgram2b.gap unused foo ../../input/flow.2  multitrack.flow
+#
+#
+## multiple singleton {} blocks in grammar (see nt_stem)
+#
+#RUN_CPP_FLAGS=""
+#GAPC="../../../gapc -t"
+#
+#check_new_old_eq single_block.gap unused count CCAAAGG block
+#
+#check_new_old_eq elm.gap unused enumenum '1+2*3' prodcopy
+#
+#check_new_old_eq optimalMCM.gap unused minmemminmult '[3x4]*[4x3]' extends
+#
+#
+## test case for multiple classifying choice fns -> classify optimization
+## minimal example for part of the pknotsRG multi choice fns classify bug
+#check_new_old_eq mchoice.gap unused shape 'gattaca' multiplechoiceclass
+#
+## FIXME add pknotsRG shape5
+#
+#GAPC="../../../gapc -t --cyk --kbacktrack"
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq pknotsRG.gap unused mfepp 'acgucgaaauaaaugccuugucugcuauauucgacgcgagcuuaauauuuggggcc' index
+#
+#
+#GAPC="../../../gapc -t "
+#
+#check_new_old_eq tdm2hp.gap unused pretty aaacccggggaauuccuu tabledim
+#check_new_old_eq tdm2hporig.gap unused pf gaauacccacggaugguagauuucgcuuuugggugaacuugccacgcccccgacggucgcgagcuuaucugcuauaccccaauugagaauacagggaacuu tabledim
+#
+#
+#GAPC="../../../gapc -t --kbacktrace --no-coopt"
+#RUN_CPP_FLAGS=""
+#
+#check_new_old_eq nussinov2.gap unused bpmaxpp caguagucagcu nocooptkbt
+#
+#GAPC="../../../gapc -t --kbacktrace "
+#RUN_CPP_FLAGS=" gggaaaaccc "
+#
+#check_new_old_eq multfilter.gap unused bpmaxpp aggaaaacca multitrack.filter
+#
+#GAPC="../../../gapc -t  "
+#RUN_CPP_FLAGS=" cagu "
+#
+#check_new_old_eq aliglob2.gap unused enum cag multitrack.enum
+#
+#
+#RUN_CPP_FLAGS=""
+#
+#check_compiler_output ../../grammar2 elmnoterm.gap buyer compile grep "Function char is not defined"
+#
+#GAPC="../../../gapc -t  "
+#RUN_CPP_FLAGS=""
+#GRAMMAR=../../grammar2
+#
+#check_new_old_eq multigrammar.gap unused seller '1+2*3*4+5' multigrammar
+#
+#check_new_old_eq ochoice.gap unused buyer '1+2*3*4+5' optchoice
+#
+#
+#GAPC="../../../gapc --tab-all  "
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#GRAMMAR=../../grammar2
+#
+#check_new_old_eq p7.gap unused mfe 'gagacugcagucc' tablegen
+#check_new_old_eq p72.gap unused mfe 'gagacugcagucc' tablegen
+#
+#GAPC="../../../gapc --tab-all --cyk --kbacktrace"
+#GRAMMAR=../../grammar2
+#RUN_CPP_FLAGS=""
+#
+#check_new_old_eq rf01380.gap unused cykpp 'AGUCA' tablegen.rightlin
+#
+#GAPC="../../../gapc -t --kbest"
+#RUN_CPP_FLAGS="-k 5 -P ../../../librna/vienna/rna_turner1999.par -f"
+#GRAMMAR=../../grammar
+#
+#check_new_old_eq adpf.gap unused shapemfe ../../input/rna200 kbest
+#
+#
+#GAPC="../../../gapc --tab-all"
+#RUN_CPP_FLAGS="AA "
+#GRAMMAR=../../grammar2
+#check_new_old_eq menum.gap unused enumi "AA" multi.enum
+#
+#
+#RUN_CPP_FLAGS=""
+#GAPC="../../../gapc -t "
+#GRAMMAR=../../grammar2
+#
+#check_compiler_output ../../grammar2 ttcounterr.gap test compile.multi grep "does not match"
+#
+#GRAMMAR=../../grammar
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#
+#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t1999
+#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t1999
+#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t1999
+#
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner2004.par"
+#
+#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t2004
+#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t2004
+#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t2004
+#
+#
+#RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner1999.par"
+#
+#GAPC="../../../gapc -t"
+#
+#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t1999
+#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t1999
+#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t1999
+#
+#GAPC="../../../gapc -t"
+#RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner2004.par"
+#
+#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t2004
+#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t2004
+#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t2004
+#
+#RUN_CPP_FLAGS="-f"
+#GRAMMAR=../../grammar2
+#GAPC="../../../gapc -t"
+#
+#check_new_old_eq escape.gap unused acount ../../input/esc esc
+#
+#RUN_CPP_FLAGS="c"
+#GRAMMAR=../../grammar2
+#GAPC="../../../gapc -t --kbacktrace"
+#
+## from mmoehl
+#check_new_old_eq interaction.gap unused bpmaxpp g multitrack.kbt
+#
+#GAPC="../../../gapc -t "
+#GRAMMAR=../../grammar2
+#RUN_CPP_FLAGS="abc"
+#
+#check_new_old_eq mcount.gap unused cnt abc multitrack.count
+#
+#RUN_CPP_FLAGS="ac"
+#
+#check_new_old_eq trackpos.gap unused cnt dc multitrack.trackpos
+#
+#GRAMMAR=../../grammar2
+#RUN_CPP_FLAGS=""
+#
+#check_new_old_eq overlay.gap unused count '1+2*3*4*5' overlay
+#
+#GAPC="../../../gapc -t --kbacktrace"
+#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+#check_new_old_eq backtraceminys.gap unused  mfepre a kbt
+#
+#GAPC="../../../gapc -t --cyk"
+#RUN_CPP_FLAGS=""
+#
+#GRAMMAR=../../grammar2
+#
+#check_new_old_eq adpfiupac.gap unused mfepp agcugucaugcagucguagucaguca iupac
+#
+#GRAMMAR=../../grammar2
+#check_new_old_eq locomotif.gap unused pretty acugacugaacuguacguugaugac foo
+#
+##test for new functions to rope: "front", "back" and "tail". For MacOSx the shape datatype has problems with hashing, thus we need a rope version for the shape algebras, but that rope first has to implement the aforementioned functions.
+#GRAMMAR=../../grammar
+#GAPC="../../../gapc"
+#check_new_old_eq macrostate.gap unused shape1count acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc shape_t
+#check_new_old_eq macrostate.gap unused shape1ropecount acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc rope
+#
+## we are here testing of seg fault due to wrongly increased Iterator in hashmap (subopt.cc) passes
+## See issue #38 @ github.com/jlab/gapc
+#GAPC="../../../gapc --subopt"
+#check_new_old_eq rnashapesmfe.gap unused mfeppshape "A" foo
+
+#test new FLOAT terminal parser
+check_new_old_eq testfloat.gap unused enum "23" floatint
+check_new_old_eq testfloat.gap unused enum "23.4" justfloat
+check_new_old_eq testfloat.gap unused enum "23.45" largerfloat
+check_new_old_eq testfloat.gap unused enum "23.45678" largerfloat2
+check_new_old_eq testfloat.gap unused enum "23.00000009" smallpostradix
+check_new_old_eq testfloat.gap unused enum "2.345e+06" failscientific

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -3,420 +3,420 @@ DEFAULT_LDLIBS_EXTRA=$LDLIBS_EXTRA
 DEFAULT_CPPFLAGS_EXTRA=$CPPFLAGS_EXTRA
 DEFAULT_GAPC=$GAPC
 
-#check_new_old_eq elm.gap unused enum 1+2*3*4+5 foo
-#
-#check_new_old_eq loco3stem.gap unused count caucguacgucagucguagucaguugcagugcaucgacua foo
-#
-#check_new_old_eq loco3stem.gap unused count gggcguucucauagguccgcguggguuagacauucaagguuauuuuuuauccggaguuaccucaucuaauugauagauuaagaaauucuuuuguucgaauaaggcgcaguuauuuacccuuuugauuccuaaaaacuuuccgccgccgucaagaugacaaauaacaaacuugccaaggcggcauccguuuuuagauaauu bar
-#
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq rnashapes2wip.gap unused mfepp gcgcggugcgucacgcaucacauacucaucaacgaugagaagc foo
-#
-#check_new_old_eq rnashapespf.gap unused pf GGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCUGGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCU pf
-#
-#RUN_CPP_FLAGS=""
-#
-#check_new_old_eq cmsmallint.gap unused enum a foo
-#
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq adpf.gap unused shapemfepp acgugucagucagucauggucaucauacugccgua foo
-#
-#CPPFLAGS_EXTRA+="-DSTATS"
-#
-## FIXME, with optimized classify, the stat-ing of one hash-table is of no use
-## ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagugcagcgauugacggauucagucggggcauauugugcauaaugucagc
-##check_feature adpf.gap shape5 ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagug foo err grep "Hi water use: 428785\>"
-#
-#CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
-#
-#GAPC="../../../gapc -t --window-mode"
-#
-#RUN_CPP_FLAGS="-w 20 -i 5"
-#
-#check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug foo
-#
-#RUN_CPP_FLAGS="-w 23 -i 8"
-#
-#check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug bar
-#
-#RUN_CPP_FLAGS="-w 100 -i 50 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq adpf.gap unused mfepp cuccccucuucggacgcaacuuaugccuaggaccuauuuugcacagaaugagggcuagggaagagccgucccucagugagcagaguuaaguuguuguuugaguaacucccggcgggcuaagccauugcacccaaccgcuugccugucauucuggaccgggauggaaccguaccucugcacuuaagacagacuaucaaaagcguauggcggguuguggucucaagugggaggacaaucaccguauauuugaucaacgauucagggaugcucacccguuucuuauuugaaacuuggcacccggaauauucugaagccaauacaguuugugacacaaccccgucaguugagacucuuuuaacgccgugugccgacgaaucuccccacgguaugcgcuggucggucccacgagggcguauaucgccaaggcagcuuaugguaacgucgcauaccagcucaagccgguugaaauaacagguccaguuuguaggucucuucugugacguaggccugcagcaagaacugcgcaugcuugucguagaggccaauagagcugaucuggcaaucguaaagguaguguuuagguagcuucauguauucaucuuucgucaucgcaagcuaaacuugcgcucaucacuauggcgucaucugaggucguugcgagaaagaugcuagguugcgcgcauaacgacuuuaagcguuagauuccgccucucaucgggccagcgaaagacccauacgcaaacgcgcuaucgcaguaauggaauaauuggcaguacucaucgccggcgucgcuauguucuaugcucacgcucucuccaggcggcggauggucccugccagcgcucgagaggcauccaaguuggaacuauauccuaugaaucacaaugccggucacuucgcgggcuaauaaguuccucaggggaccaggacgugauuuuccgugcagggggggccggucacacgcaggagguuugggcuagcacaagcccaacaaccacau foo
-#
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-f"
-#
-#check_new_old_eq adpf.gap unused shape5 "../../input/rna127" bar 
-#
-#RUN_CPP_FLAGS=""
-#CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
-## under Linux -lgmpxx pulls automatically -lgmp, Solaris does not
-#LDLIBS_EXTRA+=" -lgmp -lgmpxx"
-#
-#check_new_old_eq elm.gap unused acount '1+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+1' foo
-#
-#CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
-#LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
-#
-## Jens subopt old adpc bug report 1
-#
-#GAPC="../../../gapc -t --subopt"
-#
-## 30 %
-#RUN_CPP_FLAGS="-d 552 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt30
-#
-## 31 %
-#GAPC="../../../gapc -t --cyk --subopt"
-#RUN_CPP_FLAGS="-d 570 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt31
-#
-## Jens subopt old adpc bug report 2 (prob sum > 1.0)
-#
-#GAPC="../../../gapc -t --subopt"
-#RUN_CPP_FLAGS="-d 1090 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq adpf_nonamb.gap unused mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA subopt
-#
-#check_feature adpf_nonamb.gap mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA suboptpfsum out $KSH ../check_prob_sum 9.33773
-#
-##
-#
-## another Jens subopt RNAshapes -r -s  Probability sum > 1.0 bug
-## mail from Date: Fri, 13 Feb 2009 11:16:32 
-#
-#RUN_CPP_FLAGS="-d 224 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_feature adpf_nonamb.gap mfepppf UCACCGUCGGAAAGUGUGCGCUUUCCCUGAUGAGCCCAAAAGGGCGAAACGGUAC suboptpfsum2 out $KSH ../check_prob_sum 5.06405e+08
-#
-##
-#
-#GAPC="../../../gapc -t"
-#
-#check_new_old_eq adpf_nonamb.gap unused shape5pf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA shapesubopt
-#
-#GAPC="../../../gapc --tab-all"
-#RUN_CPP_FLAGS="-f"
-#
-## FIXME remove - obsoleted by external test case, which is more robust
-##check_new_old_eq adpf_nonamb.gap unused shape5pfx ../../input/rna150 shapefpffilter
-#
-#
-##GSL_RNG_SEED=`../rand 1`
-##export GSL_RNG_SEED
-#
-#RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par -f"
-#GAPC="../../../gapc -t --sample"
-#
-#check_feature adpf.gap pfsampleshape ../../input/rna100 sample out $KSH ../check_samples ../adpf.rna100shapepf 0.000349275 0.00005
-#
-#
-## Sequence from Jens RNAshapes sampling mode bug report
-#
-#RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_feature adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample out $KSH ../check_samples ../nonamb_shape_pf.log 6.33459e-05 0.00005
-#
-## Sequence from Jens RNAshapes sampling mode bug report, distribution test
-#
-#RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_feature_repeat_mean_var adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample2
-#
-## Too much sample output bug ( see a9fed4287fda and 980a3871b4a7 )
-#GAPC="../../../gapc -t --sample --cyk"
-#RUN_CPP_FLAGS="-r 1 -P ../../../librna/vienna/rna_turner1999.par -f"
-#check_feature adpf_nonamb.gap pfsampleshapeall ../../input/rna400 samplecount out $KSH ../check_sample_count
-#
-#RUN_CPP_FLAGS="-f"
-#GAPC="../../../gapc -t"
-#
-#check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeone
-#
-#CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
-#LDLIBS_EXTRA+=" -lgmp -lgmpxx"
-#
-#check_new_old_eq adpf.gap unused cart ../../input/rna150 cartesian
-#
-#GAPC="../../../gapc -t --backtrack"
-#
-#check_new_old_eq adpf.gap unused cartpp2 ../../input/rna20 cartesian2
-#
-#CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
-#LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
-#
-#RUN_CPP_FLAGS="-f"
-#GAPC="../../../gapc -t --backtrack"
-#
-#check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeonebt
-#
-#GAPC="../../../gapc -t --kbacktrack"
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq adpf_nonamb.gap unused shapemfepf acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbt
-#
-## FIXME remove - obsoleted by external test case, which is more robust
-##check_new_old_eq adpf_nonamb.gap unused shapemfepfx acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbtpfx
-#
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
-#GAPC="../../../gapc -t --cyk --kbacktrack"
-#
-#check_new_old_eq helene.gap unused mfepp ../../input/rna100 rope
-#
-#
-#check_external extpfx ../check_shape_filter_old_new "../../test/shapemfepfx/main -w 2 -i 1 -P ../../../librna/vienna/rna_turner1999.par" $REF/shapemfepfx.150.log 0.000001 0.000001 2 `cat ../../input/rna150`
-#
-#check_external extsample ../check_shape_filter "../../test/shrepmfesample/main -r 2000 -P ../../../librna/vienna/rna_turner1999.par" $REF/shrepmfesample.2000.150.log 0.0002 0.0002 1 `cat ../../input/rna150`
-#
-#
-#check_external extpfxwindow ../../test/shapemfepfx/test.pl ../../test/shapemfepfx/main ../../test/shapemfepfx/nowindow `cat ../../input/rna100`
-#
-#
-##RUN_CPP_FLAGS="-x -300 -f"
-## thresh of 0
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
-#GAPC="../../../gapc -t --kbacktrack --cyk"
-#
-#check_new_old_eq adpf_hl.gap unused mfepp ../../input/rna200 suchthat
-#
-#
-#GAPC="../../../gapc -t --cyk --subopt-classify --kbacktrack"
-#RUN_CPP_FLAGS="-d 0 -P ../../../librna/vienna/rna_turner1999.par -f"
-#
-#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape
-#
-#RUN_CPP_FLAGS="-d 50 -P ../../../librna/vienna/rna_turner1999.par -f"
-#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape2
-#
-#RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
-#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape3
-#
-#RUN_CPP_FLAGS="-d 429 -P ../../../librna/vienna/rna_turner1999.par -f"
-#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape4
-#
-#RUN_CPP_FLAGS="-d 430 -P ../../../librna/vienna/rna_turner1999.par -f"
-#check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape5
-#
-#RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
-#check_new_old_eq adpf_nonamb.gap unused shapemfepp ../../input/rna80 subshape8
-#
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
-#GAPC="../../../gapc -t --cyk --kbacktrack"
-#check_new_old_eq adpf.gap unused shapemfeppcl ../../input/rna20 subshape6
-#
-#check_new_old_eq adpf.gap unused shapemfeppshcl ../../input/rna20 subshape7
-#
-#RUN_CPP_FLAGS=""
-#
-#
-## FIXME tab heuristic (-t) is not optimal for this grammar
-#GAPC="../../../gapc --tab-all"
-#check_new_old_eq structure2shape.gap unused shape5 '..(((...((......))...(((.....)))....)))..' structure
-#
-#
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-f"
-#check_new_old_eq flowgram.gap unused foo ../../input/flow  flow
-#
-#RUN_CPP_FLAGS="-w 20 -i 5 -P ../../../librna/vienna/rna_turner1999.par -f"
-#GAPC="../../../gapc -t --backtrack --window-mode"
-#check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowbacktrack
-#
-#RUN_CPP_FLAGS="-w 20 -i 1 -P ../../../librna/vienna/rna_turner1999.par -f"
-#GAPC="../../../gapc -t --kbacktrack --no-coopt --window-mode"
-#check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowkbacktrack
-#
-#RUN_CPP_FLAGS=""
-#GAPC="../../../gapc -t"
-#check_new_old_eq g3pl.gap unused shapeprobls acgucguagucagucaacguacgucagu classlogspace
-#
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-f"
-#check_new_old_eq flowgram2b.gap unused score ../../input/flow.2  multitrack.flow
-#
-#GAPC="../../../gapc -t --cyk --kbacktrack"
-#check_new_old_eq flowgram2b.gap unused foo ../../input/flow.2  multitrack.flow
-#
-#
-## multiple singleton {} blocks in grammar (see nt_stem)
-#
-#RUN_CPP_FLAGS=""
-#GAPC="../../../gapc -t"
-#
-#check_new_old_eq single_block.gap unused count CCAAAGG block
-#
-#check_new_old_eq elm.gap unused enumenum '1+2*3' prodcopy
-#
-#check_new_old_eq optimalMCM.gap unused minmemminmult '[3x4]*[4x3]' extends
-#
-#
-## test case for multiple classifying choice fns -> classify optimization
-## minimal example for part of the pknotsRG multi choice fns classify bug
-#check_new_old_eq mchoice.gap unused shape 'gattaca' multiplechoiceclass
-#
-## FIXME add pknotsRG shape5
-#
-#GAPC="../../../gapc -t --cyk --kbacktrack"
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq pknotsRG.gap unused mfepp 'acgucgaaauaaaugccuugucugcuauauucgacgcgagcuuaauauuuggggcc' index
-#
-#
-#GAPC="../../../gapc -t "
-#
-#check_new_old_eq tdm2hp.gap unused pretty aaacccggggaauuccuu tabledim
-#check_new_old_eq tdm2hporig.gap unused pf gaauacccacggaugguagauuucgcuuuugggugaacuugccacgcccccgacggucgcgagcuuaucugcuauaccccaauugagaauacagggaacuu tabledim
-#
-#
-#GAPC="../../../gapc -t --kbacktrace --no-coopt"
-#RUN_CPP_FLAGS=""
-#
-#check_new_old_eq nussinov2.gap unused bpmaxpp caguagucagcu nocooptkbt
-#
-#GAPC="../../../gapc -t --kbacktrace "
-#RUN_CPP_FLAGS=" gggaaaaccc "
-#
-#check_new_old_eq multfilter.gap unused bpmaxpp aggaaaacca multitrack.filter
-#
-#GAPC="../../../gapc -t  "
-#RUN_CPP_FLAGS=" cagu "
-#
-#check_new_old_eq aliglob2.gap unused enum cag multitrack.enum
-#
-#
-#RUN_CPP_FLAGS=""
-#
-#check_compiler_output ../../grammar2 elmnoterm.gap buyer compile grep "Function char is not defined"
-#
-#GAPC="../../../gapc -t  "
-#RUN_CPP_FLAGS=""
-#GRAMMAR=../../grammar2
-#
-#check_new_old_eq multigrammar.gap unused seller '1+2*3*4+5' multigrammar
-#
-#check_new_old_eq ochoice.gap unused buyer '1+2*3*4+5' optchoice
-#
-#
-#GAPC="../../../gapc --tab-all  "
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#GRAMMAR=../../grammar2
-#
-#check_new_old_eq p7.gap unused mfe 'gagacugcagucc' tablegen
-#check_new_old_eq p72.gap unused mfe 'gagacugcagucc' tablegen
-#
-#GAPC="../../../gapc --tab-all --cyk --kbacktrace"
-#GRAMMAR=../../grammar2
-#RUN_CPP_FLAGS=""
-#
-#check_new_old_eq rf01380.gap unused cykpp 'AGUCA' tablegen.rightlin
-#
-#GAPC="../../../gapc -t --kbest"
-#RUN_CPP_FLAGS="-k 5 -P ../../../librna/vienna/rna_turner1999.par -f"
-#GRAMMAR=../../grammar
-#
-#check_new_old_eq adpf.gap unused shapemfe ../../input/rna200 kbest
-#
-#
-#GAPC="../../../gapc --tab-all"
-#RUN_CPP_FLAGS="AA "
-#GRAMMAR=../../grammar2
-#check_new_old_eq menum.gap unused enumi "AA" multi.enum
-#
-#
-#RUN_CPP_FLAGS=""
-#GAPC="../../../gapc -t "
-#GRAMMAR=../../grammar2
-#
-#check_compiler_output ../../grammar2 ttcounterr.gap test compile.multi grep "does not match"
-#
-#GRAMMAR=../../grammar
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#
-#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t1999
-#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t1999
-#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t1999
-#
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner2004.par"
-#
-#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t2004
-#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t2004
-#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t2004
-#
-#
-#RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner1999.par"
-#
-#GAPC="../../../gapc -t"
-#
-#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t1999
-#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t1999
-#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t1999
-#
-#GAPC="../../../gapc -t"
-#RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner2004.par"
-#
-#check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t2004
-#check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t2004
-#check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t2004
-#
-#RUN_CPP_FLAGS="-f"
-#GRAMMAR=../../grammar2
-#GAPC="../../../gapc -t"
-#
-#check_new_old_eq escape.gap unused acount ../../input/esc esc
-#
-#RUN_CPP_FLAGS="c"
-#GRAMMAR=../../grammar2
-#GAPC="../../../gapc -t --kbacktrace"
-#
-## from mmoehl
-#check_new_old_eq interaction.gap unused bpmaxpp g multitrack.kbt
-#
-#GAPC="../../../gapc -t "
-#GRAMMAR=../../grammar2
-#RUN_CPP_FLAGS="abc"
-#
-#check_new_old_eq mcount.gap unused cnt abc multitrack.count
-#
-#RUN_CPP_FLAGS="ac"
-#
-#check_new_old_eq trackpos.gap unused cnt dc multitrack.trackpos
-#
-#GRAMMAR=../../grammar2
-#RUN_CPP_FLAGS=""
-#
-#check_new_old_eq overlay.gap unused count '1+2*3*4*5' overlay
-#
-#GAPC="../../../gapc -t --kbacktrace"
-#RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
-#check_new_old_eq backtraceminys.gap unused  mfepre a kbt
-#
-#GAPC="../../../gapc -t --cyk"
-#RUN_CPP_FLAGS=""
-#
-#GRAMMAR=../../grammar2
-#
-#check_new_old_eq adpfiupac.gap unused mfepp agcugucaugcagucguagucaguca iupac
-#
-#GRAMMAR=../../grammar2
-#check_new_old_eq locomotif.gap unused pretty acugacugaacuguacguugaugac foo
-#
-##test for new functions to rope: "front", "back" and "tail". For MacOSx the shape datatype has problems with hashing, thus we need a rope version for the shape algebras, but that rope first has to implement the aforementioned functions.
-#GRAMMAR=../../grammar
-#GAPC="../../../gapc"
-#check_new_old_eq macrostate.gap unused shape1count acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc shape_t
-#check_new_old_eq macrostate.gap unused shape1ropecount acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc rope
-#
-## we are here testing of seg fault due to wrongly increased Iterator in hashmap (subopt.cc) passes
-## See issue #38 @ github.com/jlab/gapc
-#GAPC="../../../gapc --subopt"
-#check_new_old_eq rnashapesmfe.gap unused mfeppshape "A" foo
+check_new_old_eq elm.gap unused enum 1+2*3*4+5 foo
+
+check_new_old_eq loco3stem.gap unused count caucguacgucagucguagucaguugcagugcaucgacua foo
+
+check_new_old_eq loco3stem.gap unused count gggcguucucauagguccgcguggguuagacauucaagguuauuuuuuauccggaguuaccucaucuaauugauagauuaagaaauucuuuuguucgaauaaggcgcaguuauuuacccuuuugauuccuaaaaacuuuccgccgccgucaagaugacaaauaacaaacuugccaaggcggcauccguuuuuagauaauu bar
+
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq rnashapes2wip.gap unused mfepp gcgcggugcgucacgcaucacauacucaucaacgaugagaagc foo
+
+check_new_old_eq rnashapespf.gap unused pf GGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCUGGAGAGAUGGCUGAGUGGUUGAUAGCUCCGGUCUUGAAAACCGGUAUAGUUCUAGGAACUAUCGAGGGUUCGAAUCCCUCUCUCUCCU pf
+
+RUN_CPP_FLAGS=""
+
+check_new_old_eq cmsmallint.gap unused enum a foo
+
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq adpf.gap unused shapemfepp acgugucagucagucauggucaucauacugccgua foo
+
+CPPFLAGS_EXTRA+="-DSTATS"
+
+# FIXME, with optimized classify, the stat-ing of one hash-table is of no use
+# ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagugcagcgauugacggauucagucggggcauauugugcauaaugucagc
+#check_feature adpf.gap shape5 ugucgcccgaccuguaaucgauuguuauuuccaggcucgagggcaagucuugaaaggacuaccuugucgaaguggacagug foo err grep "Hi water use: 428785\>"
+
+CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
+
+GAPC="../../../gapc -t --window-mode"
+
+RUN_CPP_FLAGS="-w 20 -i 5"
+
+check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug foo
+
+RUN_CPP_FLAGS="-w 23 -i 8"
+
+check_new_old_eq adpf.gap unused bpmaxpp auagacguguaauuauugaggaacaggcaucgaucauaauaggguaucagggauacaugaauaggcuuagcgucaguuguuggcuauuccaucaucggguacaauuccauacuucgcaugggaucaaccaagcucuaguggccgccuaug bar
+
+RUN_CPP_FLAGS="-w 100 -i 50 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq adpf.gap unused mfepp cuccccucuucggacgcaacuuaugccuaggaccuauuuugcacagaaugagggcuagggaagagccgucccucagugagcagaguuaaguuguuguuugaguaacucccggcgggcuaagccauugcacccaaccgcuugccugucauucuggaccgggauggaaccguaccucugcacuuaagacagacuaucaaaagcguauggcggguuguggucucaagugggaggacaaucaccguauauuugaucaacgauucagggaugcucacccguuucuuauuugaaacuuggcacccggaauauucugaagccaauacaguuugugacacaaccccgucaguugagacucuuuuaacgccgugugccgacgaaucuccccacgguaugcgcuggucggucccacgagggcguauaucgccaaggcagcuuaugguaacgucgcauaccagcucaagccgguugaaauaacagguccaguuuguaggucucuucugugacguaggccugcagcaagaacugcgcaugcuugucguagaggccaauagagcugaucuggcaaucguaaagguaguguuuagguagcuucauguauucaucuuucgucaucgcaagcuaaacuugcgcucaucacuauggcgucaucugaggucguugcgagaaagaugcuagguugcgcgcauaacgacuuuaagcguuagauuccgccucucaucgggccagcgaaagacccauacgcaaacgcgcuaucgcaguaauggaauaauuggcaguacucaucgccggcgucgcuauguucuaugcucacgcucucuccaggcggcggauggucccugccagcgcucgagaggcauccaaguuggaacuauauccuaugaaucacaaugccggucacuucgcgggcuaauaaguuccucaggggaccaggacgugauuuuccgugcagggggggccggucacacgcaggagguuugggcuagcacaagcccaacaaccacau foo
+
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-f"
+
+check_new_old_eq adpf.gap unused shape5 "../../input/rna127" bar 
+
+RUN_CPP_FLAGS=""
+CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
+# under Linux -lgmpxx pulls automatically -lgmp, Solaris does not
+LDLIBS_EXTRA+=" -lgmp -lgmpxx"
+
+check_new_old_eq elm.gap unused acount '1+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+11+2*3*4+5*3*2*2*3*1+1+3+1' foo
+
+CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
+LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
+
+# Jens subopt old adpc bug report 1
+
+GAPC="../../../gapc -t --subopt"
+
+# 30 %
+RUN_CPP_FLAGS="-d 552 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt30
+
+# 31 %
+GAPC="../../../gapc -t --cyk --subopt"
+RUN_CPP_FLAGS="-d 570 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq rnashapesmfe.gap unused mfepp ugcuagucagcuaucgacucgugcagcaguacgaucagcauagcuagcacuacgcua subopt31
+
+# Jens subopt old adpc bug report 2 (prob sum > 1.0)
+
+GAPC="../../../gapc -t --subopt"
+RUN_CPP_FLAGS="-d 1090 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq adpf_nonamb.gap unused mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA subopt
+
+check_feature adpf_nonamb.gap mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA suboptpfsum out $KSH ../check_prob_sum 9.33773
+
+#
+
+# another Jens subopt RNAshapes -r -s  Probability sum > 1.0 bug
+# mail from Date: Fri, 13 Feb 2009 11:16:32 
+
+RUN_CPP_FLAGS="-d 224 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_feature adpf_nonamb.gap mfepppf UCACCGUCGGAAAGUGUGCGCUUUCCCUGAUGAGCCCAAAAGGGCGAAACGGUAC suboptpfsum2 out $KSH ../check_prob_sum 5.06405e+08
+
+#
+
+GAPC="../../../gapc -t"
+
+check_new_old_eq adpf_nonamb.gap unused shape5pf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAAuCCCAuCGGuCGCGCCA shapesubopt
+
+GAPC="../../../gapc --tab-all"
+RUN_CPP_FLAGS="-f"
+
+# FIXME remove - obsoleted by external test case, which is more robust
+#check_new_old_eq adpf_nonamb.gap unused shape5pfx ../../input/rna150 shapefpffilter
+
+
+#GSL_RNG_SEED=`../rand 1`
+#export GSL_RNG_SEED
+
+RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par -f"
+GAPC="../../../gapc -t --sample"
+
+check_feature adpf.gap pfsampleshape ../../input/rna100 sample out $KSH ../check_samples ../adpf.rna100shapepf 0.000349275 0.00005
+
+
+# Sequence from Jens RNAshapes sampling mode bug report
+
+RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_feature adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample out $KSH ../check_samples ../nonamb_shape_pf.log 6.33459e-05 0.00005
+
+# Sequence from Jens RNAshapes sampling mode bug report, distribution test
+
+RUN_CPP_FLAGS="-r 1000 -P ../../../librna/vienna/rna_turner1999.par"
+
+check_feature_repeat_mean_var adpf_nonamb.gap pfsampleshape AGAGAACAUGAGAGAGAUUCCCAACAGAGGCCUGCACGCACUUGGACUCU sample2
+
+# Too much sample output bug ( see a9fed4287fda and 980a3871b4a7 )
+GAPC="../../../gapc -t --sample --cyk"
+RUN_CPP_FLAGS="-r 1 -P ../../../librna/vienna/rna_turner1999.par -f"
+check_feature adpf_nonamb.gap pfsampleshapeall ../../input/rna400 samplecount out $KSH ../check_sample_count
+
+RUN_CPP_FLAGS="-f"
+GAPC="../../../gapc -t"
+
+check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeone
+
+CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
+LDLIBS_EXTRA+=" -lgmp -lgmpxx"
+
+check_new_old_eq adpf.gap unused cart ../../input/rna150 cartesian
+
+GAPC="../../../gapc -t --backtrack"
+
+check_new_old_eq adpf.gap unused cartpp2 ../../input/rna20 cartesian2
+
+CPPFLAGS_EXTRA=$DEFAULT_CPPFLAGS_EXTRA
+LDLIBS_EXTRA=$DEFAULT_LDLIBS_EXTRA
+
+RUN_CPP_FLAGS="-f"
+GAPC="../../../gapc -t --backtrack"
+
+check_new_old_eq nussinov.gap unused bpmax1pp ../../input/rna150 takeonebt
+
+GAPC="../../../gapc -t --kbacktrack"
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq adpf_nonamb.gap unused shapemfepf acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbt
+
+# FIXME remove - obsoleted by external test case, which is more robust
+#check_new_old_eq adpf_nonamb.gap unused shapemfepfx acgccucuucgaaguucaggauuugaccgccgcaugcgaacucggauuacgaaacauuuc kbtpfx
+
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
+GAPC="../../../gapc -t --cyk --kbacktrack"
+
+check_new_old_eq helene.gap unused mfepp ../../input/rna100 rope
+
+
+check_external extpfx ../check_shape_filter_old_new "../../test/shapemfepfx/main -w 2 -i 1 -P ../../../librna/vienna/rna_turner1999.par" $REF/shapemfepfx.150.log 0.000001 0.000001 2 `cat ../../input/rna150`
+
+check_external extsample ../check_shape_filter "../../test/shrepmfesample/main -r 2000 -P ../../../librna/vienna/rna_turner1999.par" $REF/shrepmfesample.2000.150.log 0.0002 0.0002 1 `cat ../../input/rna150`
+
+
+check_external extpfxwindow ../../test/shapemfepfx/test.pl ../../test/shapemfepfx/main ../../test/shapemfepfx/nowindow `cat ../../input/rna100`
+
+
+#RUN_CPP_FLAGS="-x -300 -f"
+# thresh of 0
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
+GAPC="../../../gapc -t --kbacktrack --cyk"
+
+check_new_old_eq adpf_hl.gap unused mfepp ../../input/rna200 suchthat
+
+
+GAPC="../../../gapc -t --cyk --subopt-classify --kbacktrack"
+RUN_CPP_FLAGS="-d 0 -P ../../../librna/vienna/rna_turner1999.par -f"
+
+check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape
+
+RUN_CPP_FLAGS="-d 50 -P ../../../librna/vienna/rna_turner1999.par -f"
+check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape2
+
+RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
+check_new_old_eq adpf.gap unused shapemfepp ../../input/rna80 subshape3
+
+RUN_CPP_FLAGS="-d 429 -P ../../../librna/vienna/rna_turner1999.par -f"
+check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape4
+
+RUN_CPP_FLAGS="-d 430 -P ../../../librna/vienna/rna_turner1999.par -f"
+check_new_old_eq adpf.gap unused shapemfepp ../../input/rna20 subshape5
+
+RUN_CPP_FLAGS="-d 100 -P ../../../librna/vienna/rna_turner1999.par -f"
+check_new_old_eq adpf_nonamb.gap unused shapemfepp ../../input/rna80 subshape8
+
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par -f"
+GAPC="../../../gapc -t --cyk --kbacktrack"
+check_new_old_eq adpf.gap unused shapemfeppcl ../../input/rna20 subshape6
+
+check_new_old_eq adpf.gap unused shapemfeppshcl ../../input/rna20 subshape7
+
+RUN_CPP_FLAGS=""
+
+
+# FIXME tab heuristic (-t) is not optimal for this grammar
+GAPC="../../../gapc --tab-all"
+check_new_old_eq structure2shape.gap unused shape5 '..(((...((......))...(((.....)))....)))..' structure
+
+
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-f"
+check_new_old_eq flowgram.gap unused foo ../../input/flow  flow
+
+RUN_CPP_FLAGS="-w 20 -i 5 -P ../../../librna/vienna/rna_turner1999.par -f"
+GAPC="../../../gapc -t --backtrack --window-mode"
+check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowbacktrack
+
+RUN_CPP_FLAGS="-w 20 -i 1 -P ../../../librna/vienna/rna_turner1999.par -f"
+GAPC="../../../gapc -t --kbacktrack --no-coopt --window-mode"
+check_new_old_eq adpf.gap unused mfepp ../../input/rna80 windowkbacktrack
+
+RUN_CPP_FLAGS=""
+GAPC="../../../gapc -t"
+check_new_old_eq g3pl.gap unused shapeprobls acgucguagucagucaacguacgucagu classlogspace
+
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-f"
+check_new_old_eq flowgram2b.gap unused score ../../input/flow.2  multitrack.flow
+
+GAPC="../../../gapc -t --cyk --kbacktrack"
+check_new_old_eq flowgram2b.gap unused foo ../../input/flow.2  multitrack.flow
+
+
+# multiple singleton {} blocks in grammar (see nt_stem)
+
+RUN_CPP_FLAGS=""
+GAPC="../../../gapc -t"
+
+check_new_old_eq single_block.gap unused count CCAAAGG block
+
+check_new_old_eq elm.gap unused enumenum '1+2*3' prodcopy
+
+check_new_old_eq optimalMCM.gap unused minmemminmult '[3x4]*[4x3]' extends
+
+
+# test case for multiple classifying choice fns -> classify optimization
+# minimal example for part of the pknotsRG multi choice fns classify bug
+check_new_old_eq mchoice.gap unused shape 'gattaca' multiplechoiceclass
+
+# FIXME add pknotsRG shape5
+
+GAPC="../../../gapc -t --cyk --kbacktrack"
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq pknotsRG.gap unused mfepp 'acgucgaaauaaaugccuugucugcuauauucgacgcgagcuuaauauuuggggcc' index
+
+
+GAPC="../../../gapc -t "
+
+check_new_old_eq tdm2hp.gap unused pretty aaacccggggaauuccuu tabledim
+check_new_old_eq tdm2hporig.gap unused pf gaauacccacggaugguagauuucgcuuuugggugaacuugccacgcccccgacggucgcgagcuuaucugcuauaccccaauugagaauacagggaacuu tabledim
+
+
+GAPC="../../../gapc -t --kbacktrace --no-coopt"
+RUN_CPP_FLAGS=""
+
+check_new_old_eq nussinov2.gap unused bpmaxpp caguagucagcu nocooptkbt
+
+GAPC="../../../gapc -t --kbacktrace "
+RUN_CPP_FLAGS=" gggaaaaccc "
+
+check_new_old_eq multfilter.gap unused bpmaxpp aggaaaacca multitrack.filter
+
+GAPC="../../../gapc -t  "
+RUN_CPP_FLAGS=" cagu "
+
+check_new_old_eq aliglob2.gap unused enum cag multitrack.enum
+
+
+RUN_CPP_FLAGS=""
+
+check_compiler_output ../../grammar2 elmnoterm.gap buyer compile grep "Function char is not defined"
+
+GAPC="../../../gapc -t  "
+RUN_CPP_FLAGS=""
+GRAMMAR=../../grammar2
+
+check_new_old_eq multigrammar.gap unused seller '1+2*3*4+5' multigrammar
+
+check_new_old_eq ochoice.gap unused buyer '1+2*3*4+5' optchoice
+
+
+GAPC="../../../gapc --tab-all  "
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+GRAMMAR=../../grammar2
+
+check_new_old_eq p7.gap unused mfe 'gagacugcagucc' tablegen
+check_new_old_eq p72.gap unused mfe 'gagacugcagucc' tablegen
+
+GAPC="../../../gapc --tab-all --cyk --kbacktrace"
+GRAMMAR=../../grammar2
+RUN_CPP_FLAGS=""
+
+check_new_old_eq rf01380.gap unused cykpp 'AGUCA' tablegen.rightlin
+
+GAPC="../../../gapc -t --kbest"
+RUN_CPP_FLAGS="-k 5 -P ../../../librna/vienna/rna_turner1999.par -f"
+GRAMMAR=../../grammar
+
+check_new_old_eq adpf.gap unused shapemfe ../../input/rna200 kbest
+
+
+GAPC="../../../gapc --tab-all"
+RUN_CPP_FLAGS="AA "
+GRAMMAR=../../grammar2
+check_new_old_eq menum.gap unused enumi "AA" multi.enum
+
+
+RUN_CPP_FLAGS=""
+GAPC="../../../gapc -t "
+GRAMMAR=../../grammar2
+
+check_compiler_output ../../grammar2 ttcounterr.gap test compile.multi grep "does not match"
+
+GRAMMAR=../../grammar
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+
+check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t1999
+check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t1999
+check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t1999
+
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner2004.par"
+
+check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG mfe1.t2004
+check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG mfe2.t2004
+check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC mfe3.t2004
+
+
+RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner1999.par"
+
+GAPC="../../../gapc -t"
+
+check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t1999
+check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t1999
+check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t1999
+
+GAPC="../../../gapc -t"
+RUN_CPP_FLAGS="-t 50.742 -P ../../../librna/vienna/rna_turner2004.par"
+
+check_new_old_eq adpf.gap unused mfepp UUGCGCCGAUGGUUUGAGCAGCAACGCGAUCUACUUUCCAUCAGGAUAAACGUUGACUUUUAGUAAGAAACACAGCCUCAGCUAGGCUGCCCUUAUAGUUCAACG temp50.mfe1.t2004
+check_new_old_eq adpf.gap unused mfepp CCCUGAUACCCUCAUGCCUCGUGG temp50.mfe2.t2004
+check_new_old_eq adpf.gap unused mfepp GGCGAGCGAGCCCCGGGCGGACGCGCGCCCGAAACGGGCGCGCGCCGCCCGGAAAGGCACGCCGCC temp50.mfe3.t2004
+
+RUN_CPP_FLAGS="-f"
+GRAMMAR=../../grammar2
+GAPC="../../../gapc -t"
+
+check_new_old_eq escape.gap unused acount ../../input/esc esc
+
+RUN_CPP_FLAGS="c"
+GRAMMAR=../../grammar2
+GAPC="../../../gapc -t --kbacktrace"
+
+# from mmoehl
+check_new_old_eq interaction.gap unused bpmaxpp g multitrack.kbt
+
+GAPC="../../../gapc -t "
+GRAMMAR=../../grammar2
+RUN_CPP_FLAGS="abc"
+
+check_new_old_eq mcount.gap unused cnt abc multitrack.count
+
+RUN_CPP_FLAGS="ac"
+
+check_new_old_eq trackpos.gap unused cnt dc multitrack.trackpos
+
+GRAMMAR=../../grammar2
+RUN_CPP_FLAGS=""
+
+check_new_old_eq overlay.gap unused count '1+2*3*4*5' overlay
+
+GAPC="../../../gapc -t --kbacktrace"
+RUN_CPP_FLAGS="-P ../../../librna/vienna/rna_turner1999.par"
+check_new_old_eq backtraceminys.gap unused  mfepre a kbt
+
+GAPC="../../../gapc -t --cyk"
+RUN_CPP_FLAGS=""
+
+GRAMMAR=../../grammar2
+
+check_new_old_eq adpfiupac.gap unused mfepp agcugucaugcagucguagucaguca iupac
+
+GRAMMAR=../../grammar2
+check_new_old_eq locomotif.gap unused pretty acugacugaacuguacguugaugac foo
+
+#test for new functions to rope: "front", "back" and "tail". For MacOSx the shape datatype has problems with hashing, thus we need a rope version for the shape algebras, but that rope first has to implement the aforementioned functions.
+GRAMMAR=../../grammar
+GAPC="../../../gapc"
+check_new_old_eq macrostate.gap unused shape1count acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc shape_t
+check_new_old_eq macrostate.gap unused shape1ropecount acuguagucugagucacguuaucuggucguaucgaucgaucgaucacuguaguc rope
+
+# we are here testing of seg fault due to wrongly increased Iterator in hashmap (subopt.cc) passes
+# See issue #38 @ github.com/jlab/gapc
+GAPC="../../../gapc --subopt"
+check_new_old_eq rnashapesmfe.gap unused mfeppshape "A" foo
 
 #test new FLOAT terminal parser
 check_new_old_eq testfloat.gap unused enum "23" floatint


### PR DESCRIPTION
Although Georg's diss mentions a FLOAT terminal parse, it was not yet implemented. I've here added according code, but its current version is 
  1. limited to simple xxx.yyyy float notation, i.e. no scientific notation like x.yyy+e06 
  1. not performance optimized