### PR TITLE
Add term args

### DIFF
--- a/rtlib/terminal.hh
+++ b/rtlib/terminal.hh
@@ -201,14 +201,10 @@ inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j) {
 
 template<typename alphabet, typename pos_type, typename T, typename X>
 inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j, X pattern) {
-  // std::cerr << "länge pattern: " << strlen(pattern) << "\n";
-  assert(i+strlen(pattern) == j);  // ToDo: double check against yield size
+  assert(i+strlen(pattern) == j);
   Rope res;
   pos_type pos_pattern = 0;
-  // std::cerr << "test rope(i=" << i << ", j=" << j << "):\n";
   for (pos_type a = i; a < j; a++, pos_pattern++) {
-	  // std::cerr << "seq[" << a << "] = " << seq[a] << " == pattern[" << pos_pattern << "] = " << pattern[pos_pattern] << " results in " << (seq[a] == pattern[pos_pattern]) << "\n";
-
 	  if (seq[a] != pattern[pos_pattern]) {
 		  Rope r;
 		  empty(r);
@@ -216,7 +212,6 @@ inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j, X pattern) {
 	  }
 	  append(res, seq[a]);
   }
-  // std::cerr << "\n";
   return res;
 }
 

--- a/rtlib/terminal.hh
+++ b/rtlib/terminal.hh
@@ -199,6 +199,27 @@ inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j) {
   return r;
 }
 
+template<typename alphabet, typename pos_type, typename T, typename X>
+inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j, X pattern) {
+  // std::cerr << "länge pattern: " << strlen(pattern) << "\n";
+  assert(i+strlen(pattern) == j);  // ToDo: double check against yield size
+  Rope res;
+  pos_type pos_pattern = 0;
+  // std::cerr << "test rope(i=" << i << ", j=" << j << "):\n";
+  for (pos_type a = i; a < j; a++, pos_pattern++) {
+	  // std::cerr << "seq[" << a << "] = " << seq[a] << " == pattern[" << pos_pattern << "] = " << pattern[pos_pattern] << " results in " << (seq[a] == pattern[pos_pattern]) << "\n";
+
+	  if (seq[a] != pattern[pos_pattern]) {
+		  Rope r;
+		  empty(r);
+		  return r;
+	  }
+	  append(res, seq[a]);
+  }
+  // std::cerr << "\n";
+  return res;
+}
+
 template<typename alphabet, typename pos_type, typename T>
 inline Rope ROPE0(Basic_Sequence<alphabet, pos_type> &seq, T i, T j) {
   assert(i <= j);

--- a/rtlib/terminal.hh
+++ b/rtlib/terminal.hh
@@ -199,6 +199,8 @@ inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j) {
   return r;
 }
 
+// a ROPE terminal parser that accepts an argument that restricts parse to this pattern
+// for example ROPE("stefan") would only yield if sub-word contains "stefan"
 template<typename alphabet, typename pos_type, typename T, typename X>
 inline Rope ROPE(Basic_Sequence<alphabet, pos_type> &seq, T i, T j, X pattern) {
   assert(i+strlen(pattern) == j);

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -2440,7 +2440,7 @@ void Alt::Simple::init_multi_ys() {
 	assert(tracks_ == 1);
 
 	// a terminal like CHAR or ROPE can have one argument, that is an implicit filter like
-	// CHAR('a') or ROPE("kurt"), which shall only accept sub-words that are 'a' or 'kurt', respectively
+	// CHAR('a') or ROPE("stefan"), which shall only accept sub-words that are 'a' or 'stefan', respectively
 	// if this argument is of a certain length, it should determine the yield size of the terminal
 	// parser. Therefore we here iterate through all arguments (currently just one 2021-05-17) and
 	// look for the longest. If the result is > 0, we set the terminal_ys to this value.

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -2444,15 +2444,19 @@ void Alt::Simple::init_multi_ys() {
 	// if this argument is of a certain length, it should determine the yield size of the terminal
 	// parser. Therefore we here iterate through all arguments (currently just one 2021-05-17) and
 	// look for the longest. If the result is > 0, we set the terminal_ys to this value.
-    Yield::Poly max_terminal_arg_yield = Yield::Poly(0);
-    for (std::list<Fn_Arg::Base*>::iterator i = args.begin(); i != args.end(); ++i) {
-        Fn_Arg::Const *fn = dynamic_cast<Fn_Arg::Const*>(*i);
-		if (fn) {
-			max_terminal_arg_yield *= fn->expr().yield_size().high();
+	// However, this mechanism is only valid for terminal parsers that consume input, i.e. NOT for CONST_xxx
+	// terminal parser, that inject values for later use in algebras.
+    if (name->rfind("CONST_", 0) != 0) {
+        Yield::Poly max_terminal_arg_yield = Yield::Poly(0);
+        for (std::list<Fn_Arg::Base*>::iterator i = args.begin(); i != args.end(); ++i) {
+			Fn_Arg::Const *fn = dynamic_cast<Fn_Arg::Const*>(*i);
+			if (fn) {
+				max_terminal_arg_yield *= fn->expr().yield_size().high();
+			}
 		}
-    }
-    if (max_terminal_arg_yield > 0) {
-        terminal_ys.set(max_terminal_arg_yield, max_terminal_arg_yield);
+		if (max_terminal_arg_yield > 0) {
+			terminal_ys.set(max_terminal_arg_yield, max_terminal_arg_yield);
+		}
     }
 
     m_ys(0) = terminal_ys;

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -319,7 +319,7 @@ class Simple : public Base {
  private:
   // Stores the yield size of this perser.
   Yield::Size terminal_ys;
-  // stores a flag as sorthand to determine if this
+  // stores a flag as shorthand to determine if this
   // Alt::Simple is just a terminal symbol. This flag
   // is set at initialization time in the constructor
   // Alt::Simple::Simple where the static hashtable

--- a/src/fn_decl.cc
+++ b/src/fn_decl.cc
@@ -119,6 +119,14 @@ void Fn_Decl::init_table() {
   ys = Yield::Size(0, 0);
   f->set_yield_size(ys);
   builtins[*s] = f;
+
+  r = new Type::External("Rope");
+  s = new std::string("ROPE");
+  f = new Fn_Decl(r, s, l);
+  f->types.push_back(r);
+  ys = Yield::Size(1, 1);  // yield size will be later determined according to constant terminal arguments like ROPE("stefan")
+  f->set_yield_size(ys);
+  builtins[*s] = f;
 }
 
 

--- a/src/type/base.cc
+++ b/src/type/base.cc
@@ -29,6 +29,10 @@ Type::Base::~Base() {}
 
 
 bool Type::Base::is(Type t) const {
+  // extra rule to match Rope (which is external) with String in terminal arguments like ROPE("stefan")
+  if ((t == Type::STRING) and (type == Type::EXTERNAL)) {
+	  return true;
+  }
   return type == t;
 }
 

--- a/testdata/grammar2/testtermarg.gap
+++ b/testdata/grammar2/testtermarg.gap
@@ -4,6 +4,7 @@ signature sig_test(alphabet, answer) {
   answer addx(alphabet, answer);
   answer addss(Rope, answer);
   answer addint(int, answer);
+  answer addconst(int, alphabet, answer);
   answer nil(void);
   choice [answer] h([answer]);
 }
@@ -12,7 +13,7 @@ algebra alg_enum auto enum;
 algebra alg_count auto count;
 
 grammar gra_test uses sig_test(axiom=A) {
-  A = addx(CHAR('x'), A) | addss(ROPE("stefan"), A) | addint(INT, A) | nil(EMPTY) # h;
+  A = addconst(CONST_INT(-98765), CHAR('x'), A) | addx(CHAR('x'), A) | addss(ROPE("stefan"), A) | addint(INT, A) | nil(EMPTY) # h;
 }
 
 instance testme = gra_test(alg_enum);

--- a/testdata/grammar2/testtermarg.gap
+++ b/testdata/grammar2/testtermarg.gap
@@ -1,0 +1,18 @@
+type Rope = extern
+
+signature sig_test(alphabet, answer) {
+  answer addx(alphabet, answer);
+  answer addss(Rope, answer);
+  answer addint(int, answer);
+  answer nil(void);
+  choice [answer] h([answer]);
+}
+
+algebra alg_enum auto enum;
+algebra alg_count auto count;
+
+grammar gra_test uses sig_test(axiom=A) {
+  A = addx(CHAR('x'), A) | addss(ROPE("stefan"), A) | addint(INT, A) | nil(EMPTY) # h;
+}
+
+instance testme = gra_test(alg_enum);

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -427,3 +427,6 @@ check_new_old_eq testfloat.gap unused enum "23.45" largerfloat
 check_new_old_eq testfloat.gap unused enum "23.45678" largerfloat2
 check_new_old_eq testfloat.gap unused enum "23.00000009" smallpostradix
 check_new_old_eq testfloat.gap unused enum "2.345e+06" failscientific
+
+# test yield size analysis of const (i.e. string) terminal arguments, like ROPE("stefan")
+check_compiler_output ../../grammar2 testtermarg.gap testme termarg grep "6), \"stefan" testtermarg.cc


### PR DESCRIPTION
extend the compiler such that the terminal parser `ROPE` can accept an argument (of type string) to restrict parses to this sequence of characters, e.g. `ROPE("kurt")` would now only yield an answer iff the sub-word is "kurt", not any other string. 

This is similar to `CHAR('A')`, but a bit more complicated since we want `ROPE` to know its now changes yield size.
Thus, `algfn(ROPE, X)` which has one moving boundary becomes `algfn(ROPE("kurt"), X)` without a moving boundary, since `ROPE` must consume exactly 4 characters.