### PR TITLE
fix: --float-accuracy

### DIFF
--- a/rtlib/generic_main.cc
+++ b/rtlib/generic_main.cc
@@ -26,6 +26,10 @@
 
 #include <iostream>
 #include <cassert>
+#ifdef FLOAT_ACC
+  #include <iomanip>
+  #include <limits>
+#endif
 
 #include "rtlib/string.hh"
 #include "rtlib/list.hh"

--- a/testdata/grammar/elm.gap
+++ b/testdata/grammar/elm.gap
@@ -197,3 +197,4 @@ instance ex = bill ( pretty ) ;
 
 instance enumenum = bill ( enum * enum ) ;
 
+instance pareto = bill ( (buyer ^ seller) * pretty) ;

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -49,7 +49,7 @@ check_new_old_eq adpf.gap unused mfepp cuccccucuucggacgcaacuuaugccuaggaccuauuuug
 GAPC="../../../gapc -t"
 RUN_CPP_FLAGS="-f"
 
-check_new_old_eq adpf.gap unused shape5 "../../input/rna127" bar 
+check_new_old_eq adpf.gap unused shape5 "../../input/rna127" bar
 
 RUN_CPP_FLAGS=""
 CPPFLAGS_EXTRA+=" -DUSE_GMP_INT"
@@ -88,7 +88,7 @@ check_feature adpf_nonamb.gap mfepppf CCacaccaacacacCuGuCACGGGAGAGAAuGuGGGuuCAAA
 #
 
 # another Jens subopt RNAshapes -r -s  Probability sum > 1.0 bug
-# mail from Date: Fri, 13 Feb 2009 11:16:32 
+# mail from Date: Fri, 13 Feb 2009 11:16:32
 
 RUN_CPP_FLAGS="-d 224 -P ../../../librna/vienna/rna_turner1999.par"
 
@@ -430,3 +430,7 @@ check_new_old_eq testfloat.gap unused enum "2.345e+06" failscientific
 
 # test yield size analysis of const (i.e. string) terminal arguments, like ROPE("stefan")
 check_compiler_output ../../grammar2 testtermarg.gap testme termarg grep "6), \"stefan" testtermarg.cc
+
+# fixing missing includes when changing gapc flag --float-accuracy
+GAPC="../../../gapc --float-accuracy 2"
+check_new_old_eq elm.gap unused pareto "1+2*3+4*5" floatacc

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -432,5 +432,6 @@ check_new_old_eq testfloat.gap unused enum "2.345e+06" failscientific
 check_compiler_output ../../grammar2 testtermarg.gap testme termarg grep "6), \"stefan" testtermarg.cc
 
 # fixing missing includes when changing gapc flag --float-accuracy
+GRAMMAR=../../grammar
 GAPC="../../../gapc --float-accuracy 2"
 check_new_old_eq elm.gap unused pareto "1+2*3+4*5" floatacc


### PR DESCRIPTION
adding a test case for missing header included when using `--float-accuracy`

A gapc call like `gapc --float-accuracy 2` generates code which fails to be compiled via g++ as it terminates complaining:
```
In file included from over_f1.hh:29:0,
                 from over_f1_main.cc:1:
Extensions/probing.hh: In function ‘void kmeans(int, int, double*, double*)’:
Extensions/probing.hh:26:36: warning: overflow in implicit constant conversion [-Woverflow]
   int minDistIndex_point2cluster = HUGE_VAL;
                                    ^~~~~~~~
Extensions/probing.hh:47:35: warning: overflow in implicit constant conversion [-Woverflow]
      minDistIndex_point2cluster = HUGE_VAL;
                                   ^~~~~~~~
over_f1_main.cc: In function ‘int main(int, char**)’:
over_f1_main.cc:68:21: error: ‘setprecision’ is not a member of ‘std’
   std::cout << std::setprecision(FLOAT_ACC) << std::fixed;
                     ^~~~~~~~~~~~
over_f1_main.cc:68:21: note: suggested alternative: ‘streamsize’
   std::cout << std::setprecision(FLOAT_ACC) << std::fixed;
                     ^~~~~~~~~~~~
                     streamsize
over_f1.mf:52: recipe for target 'over_f1_main.o' failed
make: *** [over_f1_main.o] Error 1
```
Solution is suggested here: https://stackoverflow.com/questions/12453557/setprecision-is-not-a-member-of-std