### PR TITLE
updated method to install Random for Haskell

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
+        # as of 21st Sep 2021, ubuntu-16.04 is no longer supported by github actions: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/
+        os: [ubuntu-20.04, ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Update apt


### PR DESCRIPTION
To re-enable our test suit we have to introduce to changes:
1) remove the Ubuntu 16.04 run, since github no longer supports hit
2) modify cabal install random since cabal introduced a new build/dependency system and thus we need to prefix via `v1-` commands like `install` and `update`