### PR TITLE
only execute checks in debug mode

### DIFF
--- a/src/backtrack.cc
+++ b/src/backtrack.cc
@@ -74,9 +74,11 @@ void Backtrack::apply_filter(Filter *f) {
 
 
 void Backtrack::gen_backtrack(AST &ast) {
+  #ifndef NDEBUG
   bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
+  #endif
   assert(r);
   remove_unused();
 

--- a/src/backtrack.cc
+++ b/src/backtrack.cc
@@ -74,11 +74,9 @@ void Backtrack::apply_filter(Filter *f) {
 
 
 void Backtrack::gen_backtrack(AST &ast) {
-  #ifndef NDEBUG
-  bool r = ast.check_instances(instance);
+  [[maybe_unused]] bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
-  #endif
   assert(r);
   remove_unused();
 

--- a/src/kbacktrack.cc
+++ b/src/kbacktrack.cc
@@ -88,10 +88,12 @@ void KBacktrack::gen_backtrack(AST &ast) {
   Code::Mode m = ast.code_mode();
   m.set_kscoring(true);
   ast.set_code_mode(m);
+  #ifndef NDEBUG
   bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
   assert(r);
+  #endif
   remove_unused();
 
   // ast.instance_grammar_eliminate_lists(instance);

--- a/src/kbacktrack.cc
+++ b/src/kbacktrack.cc
@@ -88,12 +88,10 @@ void KBacktrack::gen_backtrack(AST &ast) {
   Code::Mode m = ast.code_mode();
   m.set_kscoring(true);
   ast.set_code_mode(m);
-  #ifndef NDEBUG
-  bool r = ast.check_instances(instance);
+  [[maybe_unused]] bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
   assert(r);
-  #endif
   remove_unused();
 
   // ast.instance_grammar_eliminate_lists(instance);

--- a/src/subopt.cc
+++ b/src/subopt.cc
@@ -130,10 +130,12 @@ void Subopt::add_subopt_fn_args(Fn_Def *fn) {
 }
 
 void Subopt::gen_backtrack(AST &ast) {
+  #ifndef NDEBUG
   bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
   assert(r);
+  #endif
   remove_unused();
 
   // ast.instance_grammar_eliminate_lists(instance);

--- a/src/subopt.cc
+++ b/src/subopt.cc
@@ -130,12 +130,10 @@ void Subopt::add_subopt_fn_args(Fn_Def *fn) {
 }
 
 void Subopt::gen_backtrack(AST &ast) {
-  #ifndef NDEBUG
-  bool r = ast.check_instances(instance);
+  [[maybe_unused]] bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
   assert(r);
-  #endif
   remove_unused();
 
   // ast.instance_grammar_eliminate_lists(instance);

--- a/src/subopt_marker.cc
+++ b/src/subopt_marker.cc
@@ -149,10 +149,12 @@ void Subopt_Marker::add_subopt_fn_args(Fn_Def *fn, const Symbol::NT &nt) {
 }
 
 void Subopt_Marker::gen_backtrack(AST &ast) {
+  #ifndef NDEBUG
   bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
   assert(r);
+  #endif
   remove_unused();
 
   // ast.instance_grammar_eliminate_lists(instance);

--- a/src/subopt_marker.cc
+++ b/src/subopt_marker.cc
@@ -149,12 +149,10 @@ void Subopt_Marker::add_subopt_fn_args(Fn_Def *fn, const Symbol::NT &nt) {
 }
 
 void Subopt_Marker::gen_backtrack(AST &ast) {
-  #ifndef NDEBUG
-  bool r = ast.check_instances(instance);
+  [[maybe_unused]] bool r = ast.check_instances(instance);
   assert(r);
   r = ast.insert_instance(instance);
   assert(r);
-  #endif
   remove_unused();
 
   // ast.instance_grammar_eliminate_lists(instance);


### PR DESCRIPTION
This is to fix warnings when **not** compiling in debug mode (assertions are not used):
```
g++  -I/usr/include   -O3  -std=c++17 -D_XOPEN_SOURCE=500 -MMD -MP -Wall -Wnon-virtual-dtor -Wno-unused-variable -Wno-parentheses -DNDEBUG -DBISONNEW   src/backtrack.cc -c -o src/backtrack.o 
src/backtrack.cc: In member function ‘virtual void Backtrack::gen_backtrack(AST&)’:
src/backtrack.cc:77:8: warning: variable ‘r’ set but not used [-Wunused-but-set-variable]
   bool r = ast.check_instances(instance);
        ^
```