### PR TITLE
Refactor gencodestyle

### DIFF
--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -271,6 +271,7 @@ void Algebra::print_code(Printer::Base &s) {
     if (!i->second->in_use())
       continue;
     s << *i->second;
+    s << endl;
   }
   s << endl;
 }

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1106,8 +1106,10 @@ Expr::Base *Alt::Simple::next_index_var(unsigned &k, size_t track,
           cond, new Expr::Less_Eq (ivar, last_var->plus(lhs_ys.high())));
       }
 
-      Statement::For *f = new Statement::For (new Statement::Var_Decl(
-        new ::Type::Size(), ivar, index.first), cond);
+      Statement::Var_Decl *loopvariable = new Statement::Var_Decl(new ::Type::Size(), ivar, index.first);
+      // flag this variable as being an iterator e.g. in for-loops, such that it won't have a trailing indent for code generation
+      loopvariable->set_itr(true);
+      Statement::For *f = new Statement::For (loopvariable, cond);
       loops.push_back(f);
       return ivar;
     }

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1106,8 +1106,10 @@ Expr::Base *Alt::Simple::next_index_var(unsigned &k, size_t track,
           cond, new Expr::Less_Eq (ivar, last_var->plus(lhs_ys.high())));
       }
 
-      Statement::Var_Decl *loopvariable = new Statement::Var_Decl(new ::Type::Size(), ivar, index.first);
-      // flag this variable as being an iterator e.g. in for-loops, such that it won't have a trailing indent for code generation
+      Statement::Var_Decl *loopvariable = new Statement::Var_Decl(
+        new ::Type::Size(), ivar, index.first);
+      // flag this variable as being an iterator e.g. in for-loops,
+      // such that it won't have a trailing indent for code generation
       loopvariable->set_itr(true);
       Statement::For *f = new Statement::For (loopvariable, cond);
       loops.push_back(f);

--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -1009,7 +1009,7 @@ void Printer::Cpp::print_names(
 void Printer::Cpp::print_eqs(const std::list<Statement::Var_Decl*> &l, char c) {
   for (std::list<Statement::Var_Decl*>::const_iterator i = l.begin();
        i != l.end(); ++i) {
-    stream << indent() << *(*i)->name << " = " << *(*i)->name << c << ";"
+    stream << indent() << *(*i)->name << " = " << *(*i)->name << c << ";";
     stream << endl;
   }
 }

--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -58,7 +58,7 @@ static std::string make_comments(const std::string &s, const std::string &c) {
        lines.begin(); i != lines.end(); ++i) {
     o << c;
     if (!(*i).empty()) {
-    	o << " ";
+      o << " ";
     }
     o << *i << '\n';
   }
@@ -121,7 +121,7 @@ void Printer::Cpp::print(const Statement::Var_Decl &stmt) {
   }
 
   if (!stmt.is_itr()) {
-	  stream << indent();
+    stream << indent();
   }
   stream << *stmt.type << ' ' << *stmt.name;
   if (stmt.rhs)
@@ -1009,7 +1009,8 @@ void Printer::Cpp::print_names(
 void Printer::Cpp::print_eqs(const std::list<Statement::Var_Decl*> &l, char c) {
   for (std::list<Statement::Var_Decl*>::const_iterator i = l.begin();
        i != l.end(); ++i) {
-    stream << indent() << *(*i)->name << " = " << *(*i)->name << c << ";" << endl;
+    stream << indent() << *(*i)->name << " = " << *(*i)->name << c << ";"
+    stream << endl;
   }
 }
 
@@ -1115,7 +1116,8 @@ void Printer::Cpp::print(const Statement::Table_Decl &t) {
   for (size_t track = t.nt().track_pos();
        track < t.nt().track_pos() + t.nt().tracks(); ++track) {
     stream << indent() << "t_" << track << "_left_most = 0;" << endl;
-    stream << indent() << "t_" << track << "_right_most = t_" << track << "_n;" << endl;
+    stream << indent() << "t_" << track << "_right_most = t_";
+    stream << track << "_n;" << endl;
   }
 
   if (wmode) {
@@ -1940,7 +1942,7 @@ void Printer::Cpp::print_cyk_fn(const AST &ast) {
   stream << indent() << "void " << class_name << "::cyk() {" << endl;
   inc_indent();
   if (!ast.cyk()) {
-	dec_indent();
+    dec_indent();
     stream << indent() << '}' << endl << endl;
     return;
   }
@@ -1989,7 +1991,8 @@ void Printer::Cpp::print_cyk_fn(const AST &ast) {
 
 
 void Printer::Cpp::print_run_fn(const AST &ast) {
-  stream << indent() << *ast.grammar()->axiom->code()->return_type << " run() {" << endl;
+  stream << indent() << *ast.grammar()->axiom->code()->return_type;
+  stream << " run() {" << endl;
   inc_indent();
   stream << indent() << "return nt_" << *ast.grammar()->axiom_name << '(';
 
@@ -2070,7 +2073,7 @@ void Printer::Cpp::print_id() {
 
 void Printer::Cpp::footer(const AST &ast) {
   if (fwd_decls) {
-	dec_indent();
+    dec_indent();
     stream << indent() << " public:" << endl;
     inc_indent();
   }
@@ -2088,7 +2091,8 @@ void Printer::Cpp::print_backtrack_fn(const AST &ast) {
     return;
   }
 
-  stream << indent() << *ast.grammar()->axiom->code()->return_type << " backtrack";
+  stream << indent() << *ast.grammar()->axiom->code()->return_type;
+  stream << " backtrack";
   print(
     ast.grammar()->axiom->code()->types, ast.grammar()->axiom->code()->names);
   stream << " {" << endl;
@@ -2182,7 +2186,7 @@ void Printer::Cpp::print_backtrack_pp(const AST &ast) {
   inc_indent();
 
   if (ast.code_mode() != Code::Mode::BACKTRACK) {
-	dec_indent();
+    dec_indent();
     stream << indent() << '}' << endl << endl;
     return;
   }
@@ -2194,7 +2198,8 @@ void Printer::Cpp::print_backtrack_pp(const AST &ast) {
     return;
   }
 
-  stream << indent() << *ast.grammar()->axiom->code()->return_type << " bt = backtrack(";
+  stream << indent() << *ast.grammar()->axiom->code()->return_type;
+  stream << " bt = backtrack(";
 
   print_axiom_args(ast);
 
@@ -2331,7 +2336,7 @@ void Printer::Cpp::print_value_pp(const AST &ast) {
   inc_indent();
   if (ast.code_mode() == Code::Mode::BACKTRACK ||
       ast.code_mode() == Code::Mode::SUBOPT) {
-	dec_indent();
+    dec_indent();
     stream << indent() << '}' << endl;
     return;
   }

--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -2475,39 +2475,39 @@ void Printer::Cpp::imports(const AST &ast) {
   }
 
   if (ast.code_mode() != Code::Mode::SUBOPT) {
-    stream << "#include <rtlib/subopt.hh>" << endl;
+    stream << "#include \"rtlib/subopt.hh\"" << endl;
   }
 
   switch (ast.get_rtlib_header()) {
     case ADP_Mode::PARETO_NOSORT_BLOCK:
-      stream << "#include <rtlib/adp_specialization/pareto_0_nosort_block.hh>"
+      stream << "#include \"rtlib/adp_specialization/pareto_0_nosort_block.hh\""
         << endl;
       break;
     case ADP_Mode::PARETO_NOSORT_STEP:
-      stream << "#include <rtlib/adp_specialization/pareto_0_nosort_step.hh>"
+      stream << "#include \"rtlib/adp_specialization/pareto_0_nosort_step.hh\""
         << endl;
       break;
     case ADP_Mode::PARETO_SORT_BLOCK:
-      stream << "#include <rtlib/adp_specialization/pareto_1_sorted_block.hh>"
+      stream << "#include \"rtlib/adp_specialization/pareto_1_sorted_block.hh\""
         << endl;
       break;
     case ADP_Mode::PARETO_SORT_STEP:
-      stream << "#include <rtlib/adp_specialization/pareto_1_sorted_step.hh>"
+      stream << "#include \"rtlib/adp_specialization/pareto_1_sorted_step.hh\""
         << endl;
       break;
     case ADP_Mode::PARETO_YUK_BLOCK:
-      stream << "#include <rtlib/adp_specialization/pareto_3_yukish_block.hh>"
+      stream << "#include \"rtlib/adp_specialization/pareto_3_yukish_block.hh\""
         << endl;
       break;
     case ADP_Mode::PARETO_YUK_STEP:
-      stream << "#include <rtlib/adp_specialization/pareto_3_yukish_step.hh>"
+      stream << "#include \"rtlib/adp_specialization/pareto_3_yukish_step.hh\""
         << endl;
       break;
     case ADP_Mode::SORT_BLOCK:
-      stream << "#include <rtlib/adp_specialization/sort_block.hh>" << endl;
+      stream << "#include \"rtlib/adp_specialization/sort_block.hh\"" << endl;
       break;
     case ADP_Mode::SORT_STEP:
-      stream << "#include <rtlib/adp_specialization/sort_step.hh>" << endl;
+      stream << "#include \"rtlib/adp_specialization/sort_step.hh\"" << endl;
       break;
     default: break;
   }
@@ -2523,7 +2523,7 @@ void Printer::Cpp::imports(const AST &ast) {
     }
   }
   stream << endl;
-  stream << "#include <rtlib/generic_opts.hh>\n";
+  stream << "#include \"rtlib/generic_opts.hh\"\n";
         stream << "#include \"rtlib/pareto_dom_sort.hh\"\n";
         stream << "#include \"rtlib/pareto_yukish_ref.hh\"\n\n";
 }
@@ -2536,7 +2536,7 @@ void Printer::Cpp::global_constants(const AST &ast) {
   }
 
   if (ast.get_float_acc() != 0) {
-    stream << "#include <rtlib/float_accuracy_operators.hh>\n";
+    stream << "#include \"rtlib/float_accuracy_operators.hh\"\n";
     stream << "const double depsilon = " << std::pow(0.1, ast.get_float_acc())
       << ";\n\n";
   }

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -604,7 +604,7 @@ class Main {
     cc.set_files(opts.in_file, opts.out_file);
     cc.prelude(opts, driver.ast);
     cc.imports(driver.ast);
-                      cc.global_constants(driver.ast);
+    cc.global_constants(driver.ast);
     driver.ast.print_code(cc);
     instance->print_code(cc);
     cc.footer(driver.ast);

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -953,6 +953,7 @@ void Grammar::print_code(Printer::Base &out) {
       for (std::list<Fn_Def*>::iterator i = l.begin(); i != l.end(); ++i) {
         out << **i;
       }
+      out << endl;
     }
   }
 }

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -453,7 +453,10 @@ void Printer::Base::set_argv(char **argv, int argc) {
     << "  GAP-C version:\n    " << gapc::version_id << "\n\n"
     << "  GAP-C call:\n    ";
   for (int i = 0; i < argc; ++i) {
-    o << argv[i] << ' ';
+    o << argv[i];
+    if (i+1 < argc) {
+      o << ' ';
+    }
   }
   o << "\n\n";
   id_string = o.str();


### PR DESCRIPTION
This PR is to clean up the style of the generated CPP code, mostly 
 - to move { into the same line as the function / statement
 - systematically use indents
 - use `""` over `<>` for includes
 - remove space after `( `in function calls
 - use `endl` instead of `\n`
I have to check all possible output, but only one out.cc / out.hh file for a simple MFE instance for nodangle grammar.