### PR TITLE
turn of build/include_subdir warnings for now

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -138,9 +138,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
     - run: pip install cpplint
-    - run: cpplint --recursive --counting 'detailed' --filter="-runtime/references" --extensions=cc,hh src/ rtlib/
+    - run: cpplint --recursive --counting 'detailed' --filter="-runtime/references,-build/include_subdir" --extensions=cc,hh src/ rtlib/
     - run: cpplint --counting 'detailed' --filter="-build/include_subdir,-readability/casting,-runtime/arrays" --extensions=c,h librna/rnalib.{c,h}
-    - run: cpplint --recursive --counting 'detailed' --filter="-runtime/references" testdata/unittest/*
+    - run: cpplint --recursive --counting 'detailed' --filter="-runtime/references,-build/include_subdir" testdata/unittest/*
     - uses: vishnudxb/cancel-workflow@v1.2
       if: failure()
       with:


### PR DESCRIPTION
I don't dare to change include locations at the moment for fear of side effects