### PR TITLE
Plot Grammar

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,9 +2,9 @@ name: github action build & CI
 
 on:
   push:
-    branches: [ master, plot_grammar, plot_grammar_style ]
+    branches: [ master, plot_grammar, plot_grammar_polish ]
   pull_request:
-    branches: [ master, plot_grammar, plot_grammar_style ]
+    branches: [ master, plot_grammar, plot_grammar_polish ]
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,9 +2,9 @@ name: github action build & CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, plot_grammar, plot_grammar_style ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, plot_grammar, plot_grammar_style ]
   workflow_dispatch:
     inputs:
       logLevel:
@@ -117,7 +117,7 @@ jobs:
       run: sudo make install
 
     - name: clone fold-grammars
-      run: git clone --branch  master https://github.com/jlab/fold-grammars.git $GITHUB_WORKSPACE/../fold-grammars
+      run: git clone --branch master https://github.com/jlab/fold-grammars.git $GITHUB_WORKSPACE/../fold-grammars
     - name: configure fold-grammars
       run: |
         cd $GITHUB_WORKSPACE/../fold-grammars

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -2965,7 +2965,7 @@ unsigned int Alt::Base::to_dot(unsigned int *nodeID, std::ostream &out) {
   to_dot_indices(this->left_indices, out);
   Alt::Simple *simple = dynamic_cast<Alt::Simple*>(this);
   if (simple) {
-    out << "<td>" << *simple->name << "</td>";
+    out << "<td>" << *simple->name;
 
     // terminal arguments e.g. CHAR('A')
     if (simple->is_terminal()) {
@@ -2982,6 +2982,8 @@ unsigned int Alt::Base::to_dot(unsigned int *nodeID, std::ostream &out) {
         }
       }
     }
+
+    out << "</td>";
   }
   Alt::Link *link = dynamic_cast<Alt::Link*>(this);
   if (link) {

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -2966,7 +2966,14 @@ void to_dot_filternameargs(Filter *filter, std::ostream &out) {
     if (arg == filter->args.begin()) {
       out << "(";
     }
-    (*arg)->put(out);
+    Expr::Const *c = dynamic_cast<Expr::Const*>(*arg);
+    if (c && c->base->is(Const::STRING)) {
+      out << "\\\"";
+      (*c).put_noquote(out);
+      out << "\\\"";
+    } else {
+      (*arg)->put(out);
+    }
     if (std::next(arg) != filter->args.end()) {
       out << ", ";
     } else {

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -441,6 +441,13 @@ class Simple : public Base {
   void init_multi_ys();
 
  private:
+  std::list<Statement::Base*> *add_filter_guards(
+    std::list<Statement::Base*> *stmts,
+    Statement::If *filter_guards);
+  std::list<Statement::Base*> *add_for_loops(
+    std::list<Statement::Base*> *stmts,
+    std::list<Statement::For *> loops,
+    bool has_index_overlay);
   void sum_rhs(
     Yield::Multi &y, std::list<Fn_Arg::Base*>::const_iterator i,
     const std::list<Fn_Arg::Base*>::const_iterator &end) const;

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -602,6 +602,7 @@ class Link : public Base {
   bool is_explicit() const {
     return !indices.empty();
   }
+  void to_dot_overlayindices(std::ostream &out, bool is_left_index);
 
  private:
   std::list<Expr::Base*> ntparas;

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -308,6 +308,7 @@ class Base {
   virtual void set_ntparas(const Loc &loc, std::list<Expr::Base*> *l);
 
   bool choice_set();
+  virtual unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 };
 
 
@@ -486,7 +487,7 @@ class Simple : public Base {
 
  public:
   void set_ntparas(std::list<Expr::Base*> *l);
-
+  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 
  private:
   std::list<Statement::Base*> *insert_index_stmts(
@@ -608,6 +609,7 @@ class Link : public Base {
   bool check_ntparas();
 
   void optimize_choice();
+  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 };
 
 
@@ -675,6 +677,7 @@ class Block : public Base {
 
   void multi_collect_factors(Runtime::Poly &p);
   void multi_init_calls(const Runtime::Poly &p, size_t base_tracks);
+  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 };
 
 
@@ -745,9 +748,13 @@ class Multi : public Base {
   void types(std::list< ::Type::Base*> &) const;
   const std::list<Statement::Var_Decl*> &ret_decls() const;
   void init_ret_decl(unsigned int i, const std::string &prefix);
+  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 };
 
-
 }  // namespace Alt
+
+// prints left or right indices of a parser to out stream.
+// used as a helper for to_dot functions
+void to_dot_indices(std::vector<Expr::Base*> indices, std::ostream &out);
 
 #endif  // SRC_ALT_HH_

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -308,6 +308,8 @@ class Base {
   virtual void set_ntparas(const Loc &loc, std::list<Expr::Base*> *l);
 
   bool choice_set();
+  void to_dot_semanticfilters(unsigned int *nodeID, unsigned int thisID,
+    std::ostream &out, std::vector<unsigned int> *childIDs = NULL);
   virtual unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 };
 

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -308,10 +308,10 @@ class Base {
   virtual void set_ntparas(const Loc &loc, std::list<Expr::Base*> *l);
 
   bool choice_set();
-  void to_dot_semanticfilters(unsigned int *nodeID, unsigned int thisID,
+  unsigned int to_dot_semanticfilters(unsigned int *nodeID, unsigned int thisID,
     std::ostream &out, std::vector<unsigned int> *childIDs = NULL);
   virtual unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
-          int plot_level, int depth);
+          int plot_level);
 };
 
 
@@ -491,7 +491,7 @@ class Simple : public Base {
  public:
   void set_ntparas(std::list<Expr::Base*> *l);
   unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
-          int plot_level, int depth);
+          int plot_level);
 
  private:
   std::list<Statement::Base*> *insert_index_stmts(
@@ -615,7 +615,7 @@ class Link : public Base {
 
   void optimize_choice();
   unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
-          int plot_level, int depth);
+          int plot_level);
 };
 
 
@@ -684,7 +684,7 @@ class Block : public Base {
   void multi_collect_factors(Runtime::Poly &p);
   void multi_init_calls(const Runtime::Poly &p, size_t base_tracks);
   unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
-          int plot_level, int depth);
+          int plot_level);
 };
 
 
@@ -756,7 +756,7 @@ class Multi : public Base {
   const std::list<Statement::Var_Decl*> &ret_decls() const;
   void init_ret_decl(unsigned int i, const std::string &prefix);
   unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
-          int plot_level, int depth);
+          int plot_level);
 };
 
 }  // namespace Alt

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -310,7 +310,8 @@ class Base {
   bool choice_set();
   void to_dot_semanticfilters(unsigned int *nodeID, unsigned int thisID,
     std::ostream &out, std::vector<unsigned int> *childIDs = NULL);
-  virtual unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
+  virtual unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
+          int plot_level, int depth);
 };
 
 
@@ -489,7 +490,8 @@ class Simple : public Base {
 
  public:
   void set_ntparas(std::list<Expr::Base*> *l);
-  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
+  unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
+          int plot_level, int depth);
 
  private:
   std::list<Statement::Base*> *insert_index_stmts(
@@ -612,7 +614,8 @@ class Link : public Base {
   bool check_ntparas();
 
   void optimize_choice();
-  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
+  unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
+          int plot_level, int depth);
 };
 
 
@@ -680,7 +683,8 @@ class Block : public Base {
 
   void multi_collect_factors(Runtime::Poly &p);
   void multi_init_calls(const Runtime::Poly &p, size_t base_tracks);
-  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
+  unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
+          int plot_level, int depth);
 };
 
 
@@ -751,7 +755,8 @@ class Multi : public Base {
   void types(std::list< ::Type::Base*> &) const;
   const std::list<Statement::Var_Decl*> &ret_decls() const;
   void init_ret_decl(unsigned int i, const std::string &prefix);
-  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
+  unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
+          int plot_level, int depth);
 };
 
 }  // namespace Alt

--- a/src/const.cc
+++ b/src/const.cc
@@ -89,6 +89,9 @@ void Const::Char::put(std::ostream &s) {
 void Const::String::put(std::ostream &o) {
   o << '"' << *s << '"';
 }
+void Const::String::put_noquote(std::ostream &o) {
+  o << *s;
+}
 
 void Const::Rational::put(std::ostream &o) {
   o << "Rational(\"" << *a << "/" << *b << "\")";

--- a/src/const.hh
+++ b/src/const.hh
@@ -200,6 +200,7 @@ class String : public Base {
 
 
   void put(std::ostream &s);
+  void put_noquote(std::ostream &s);
 };
 
 

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -97,7 +97,14 @@ void Expr::Minus::put(std::ostream &s) const {
 void Expr::Const::put(std::ostream &s) const {
   s << *base;
 }
-
+void Expr::Const::put_noquote(std::ostream &s) const {
+  ::Const::String *basestring = dynamic_cast<::Const::String*>(this->base);
+  // SMJ 2022-05-06: I've only seen quotes printing out for Strings
+  // However, for plotGrammar *.dot creation, " must be properly escaped,
+  // which is handled in alt.cc and requires an un-quoted version here
+  assert(basestring);
+  basestring->put_noquote(s);
+}
 
 void Expr::Less_Eq::put(std::ostream &s) const {
   s << '(' << *lhs << " <= " << *rhs << ')';

--- a/src/expr.hh
+++ b/src/expr.hh
@@ -117,6 +117,7 @@ class Const : public Base {
   explicit Const(char c);
 
     void put(std::ostream &s) const;
+    void put_noquote(std::ostream &s) const;
 
     Base *copy() const;
 };

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -128,10 +128,13 @@ static void parse_options(int argc, char **argv, Options *rec) {
       "Mode of specialization: 0 force block mode, 1 force stepwise mode. This"
       " is automatically set to best option if not specified.")
     ("plot-grammar", po::value<int>(),
-      "generates a graphviz dot-file from the selected (and potentially "
-      "modified) grammar.\n Valid values are 0(no plot), 1(simple plot), "
-      "2(plot with indices). Default is 0. \n"
-      "(Use 'dot -Tpdf out.dot' to generate a PDF.)\n default file is out.dot");
+      "generates a Graphviz dot-file from the selected (and potentially "
+      "modified) grammar.\nChoose a level (int) of detail:\n"
+      "  0 (default) = no output at all\n"
+      "  1 = grammar\n"
+      "  2 = add indices\n"
+      "  3 = add data types.\n"
+      "(Use 'dot -Tpdf out.dot' to generate a PDF.)\nDefault file is out.dot");
   po::options_description hidden("");
   hidden.add_options()
     ("backtrack", "deprecated for --backtrace")

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -127,10 +127,11 @@ static void parse_options(int argc, char **argv, Options *rec) {
     ("step-mode", po::value<int>(),
       "Mode of specialization: 0 force block mode, 1 force stepwise mode. This"
       " is automatically set to best option if not specified.")
-    ("plot-grammar",
+    ("plot-grammar", po::value<int>(),
       "generates a graphviz dot-file from the selected (and potentially "
-      "modified) grammar.\n(Use 'dot -Tpdf out.dot' to generate a PDF.)\n"
-      "default file is out.dot");
+      "modified) grammar.\n Valid values are 0(no plot), 1(simple plot), "
+      "2(plot with indices). Default is 0. \n"
+      "(Use 'dot -Tpdf out.dot' to generate a PDF.)\n default file is out.dot");
   po::options_description hidden("");
   hidden.add_options()
     ("backtrack", "deprecated for --backtrace")
@@ -257,9 +258,10 @@ static void parse_options(int argc, char **argv, Options *rec) {
   }
 
   if (vm.count("plot-grammar")) {
-    rec->plot_grammar = true;
+    rec->plot_grammar = vm["plot-grammar"].as<int>();
     rec->plot_grammar_file = basename(rec->out_file) + ".dot";
   }
+
 
   bool r = rec->check();
   if (!r) {
@@ -588,9 +590,9 @@ class Main {
     // dot-file for the grammar. This is handy if gapc modifies the original
     // grammar from the source file.
     // activate with command line argument --plot-grammar
-    if (opts.plot_grammar) {
+    if (opts.plot_grammar > 0) {
       unsigned int nodeID = 1;
-      grammar->to_dot(&nodeID, opts.plotgrammar_stream());
+      grammar->to_dot(&nodeID, opts.plotgrammar_stream(), opts.plot_grammar);
       Log::instance()->normalMessage(
         "Graphviz representation of selected grammar has been saved in '"
         + opts.plot_grammar_file + "'.\nUse e.g. 'dot -Tpdf "

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -126,7 +126,11 @@ static void parse_options(int argc, char **argv, Options *rec) {
       "(Standard), 1 (Sorted ADP), 2 (Pareto Eager ADP)")
     ("step-mode", po::value<int>(),
       "Mode of specialization: 0 force block mode, 1 force stepwise mode. This"
-      " is automatically set to best option if not specified.");
+      " is automatically set to best option if not specified.")
+    ("plot-grammar",
+      "generates a graphviz dot-file from the selected (and potentially "
+      "modified) grammar.\n(Use 'dot -Tpdf out.dot' to generate a PDF.)\n"
+      "default file is out.dot");
   po::options_description hidden("");
   hidden.add_options()
     ("backtrack", "deprecated for --backtrace")
@@ -250,6 +254,11 @@ static void parse_options(int argc, char **argv, Options *rec) {
   if (vm.count("step-mode")) {
     int s = vm["step-mode"].as<int>();
     rec->step_option = s;
+  }
+
+  if (vm.count("plot-grammar")) {
+    rec->plot_grammar = true;
+    rec->plot_grammar_file = basename(rec->out_file) + ".dot";
   }
 
   bool r = rec->check();
@@ -383,8 +392,8 @@ class Main {
     // suboptimal designs and present a message to the user.
     driver.ast.warn_user_table_conf_suboptimal();
 
-                      // find what type of input is read
-                      // chars, sequence of ints etc.
+    // find what type of input is read
+    // chars, sequence of ints etc.
     driver.ast.derive_temp_alphabet();
 
     r = driver.ast.check_signature();
@@ -573,6 +582,19 @@ class Main {
         Log::instance()->warning(
           "Choice function and classification optimization are disabled for "
           "specialized ADP.");
+    }
+
+    // to ease inspection of the selected grammar, one can create a graphviz
+    // dot-file for the grammar. This is handy if gapc modifies the original
+    // grammar from the source file.
+    // activate with command line argument --plot-grammar
+    if (opts.plot_grammar) {
+      unsigned int nodeID = 1;
+      grammar->to_dot(&nodeID, opts.plotgrammar_stream());
+      Log::instance()->normalMessage(
+        "Graphviz representation of selected grammar has been saved in '"
+        + opts.plot_grammar_file + "'.\nUse e.g. 'dot -Tpdf "
+        + opts.plot_grammar_file + " > foo.pdf' to generate a PDF.");
     }
 
     driver.ast.set_class_name(opts.class_name);

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -25,6 +25,8 @@
 #include <iostream>
 #include <algorithm>
 
+#include "alt.hh"
+
 #include "grammar.hh"
 #include "log.hh"
 #include "arg.hh"
@@ -1000,11 +1002,24 @@ void Grammar::remove(Symbol::NT *x) {
   tabulated.erase(nt);
 }
 
-unsigned int Grammar::to_dot(unsigned int *nodeID, std::ostream &out) {
+unsigned int Grammar::to_dot(unsigned int *nodeID, std::ostream &out,
+        int plot_grammar) {
+  int start_node;
+  unsigned int i = 1;
   out << "digraph " << *this->name << " {\n";
+  out << "compound = True;\n";
+  out << "newrank=True;\n";
+  out << "ordering=out;\n";
   for (std::list<Symbol::NT*>::const_iterator nt = this->nt_list.begin();
        nt != this->nt_list.end(); ++nt) {
-    (*nt)->to_dot(nodeID, out, false, this->axiom);
+    out << "subgraph cluster_" << i << "{\n";
+    start_node = (*nt)->to_dot(nodeID, out, false, this->axiom, plot_grammar);
+    out << "}\n";
+    if (start_node > 1) {
+        out << "node_" << start_node-1 << " -> node_" << start_node <<
+                " [ style = invis];\n";
+      }
+    i++;
   }
   out << "}\n";
   return ((unsigned int)*nodeID);

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -1008,18 +1008,23 @@ unsigned int Grammar::to_dot(unsigned int *nodeID, std::ostream &out,
   unsigned int i = 1;
   out << "digraph " << *this->name << " {\n";
   out << "compound = True;\n";
-  out << "newrank=True;\n";
-  out << "ordering=out;\n";
+  out << "newrank = True;\n";
+  out << "ordering = out;\n";
   for (std::list<Symbol::NT*>::const_iterator nt = this->nt_list.begin();
-       nt != this->nt_list.end(); ++nt) {
-    out << "subgraph cluster_" << i << "{\n";
+       nt != this->nt_list.end(); ++nt, ++i) {
+    if (nt != this->nt_list.begin()) {
+      // except for the first unit, we add an invisible node (anchor) and
+      // invisible edges from the anchor to the lhs non-terminal node of the
+      // next unit to enable vertical alignment
+      out << "node_" << start_node << " -> node_" << std::to_string(*nodeID)
+          << " [ style=invis ];\n";
+    }
+    // let's organize all nodes of a lhs non-terminal in one subgraph cluster
+    // such that it can be plotted as one unit and these units are
+    // vertically stacked, while elements in the unit are horizontally aligned
+    out << "subgraph cluster_" << i << " {\n";
     start_node = (*nt)->to_dot(nodeID, out, false, this->axiom, plot_grammar);
     out << "}\n";
-    if (start_node > 1) {
-        out << "node_" << start_node-1 << " -> node_" << start_node <<
-                " [ style = invis];\n";
-      }
-    i++;
   }
   out << "}\n";
   return ((unsigned int)*nodeID);

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -999,3 +999,13 @@ void Grammar::remove(Symbol::NT *x) {
   NTs.erase(nt);
   tabulated.erase(nt);
 }
+
+unsigned int Grammar::to_dot(unsigned int *nodeID, std::ostream &out) {
+  out << "digraph " << *this->name << " {\n";
+  for (std::list<Symbol::NT*>::const_iterator nt = this->nt_list.begin();
+       nt != this->nt_list.end(); ++nt) {
+    (*nt)->to_dot(nodeID, out, false, this->axiom);
+  }
+  out << "}\n";
+  return ((unsigned int)*nodeID);
+}

--- a/src/grammar.hh
+++ b/src/grammar.hh
@@ -206,7 +206,7 @@ class Grammar {
 
   void multi_propagate_max_filter();
 
-  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
+  unsigned int to_dot(unsigned int *nodeID, std::ostream &out, int plot_level);
 };
 
 

--- a/src/grammar.hh
+++ b/src/grammar.hh
@@ -205,6 +205,8 @@ class Grammar {
   bool multi_detect_loops();
 
   void multi_propagate_max_filter();
+
+  unsigned int to_dot(unsigned int *nodeID, std::ostream &out);
 };
 
 

--- a/src/options.hh
+++ b/src/options.hh
@@ -56,7 +56,8 @@ struct Options {
       logLevel(3),
       pareto(0), multiDimPareto(false), cutoff(65),
       float_acc(0),
-      specialization(0), step_option(0) {
+      specialization(0), step_option(0),
+      plot_grammar(false), plotgrammar_stream_(NULL) {
   }
 
 
@@ -67,6 +68,8 @@ struct Options {
     h_stream_ = NULL;
     delete m_stream_;
     m_stream_ = NULL;
+    delete plotgrammar_stream_;
+    plotgrammar_stream_ = NULL;
   }
 
 
@@ -184,7 +187,20 @@ struct Options {
     return *m_stream_;
   }
 
+  std::string plot_grammar_file;
+  bool plot_grammar;
+  std::ostream *plotgrammar_stream_;
+  std::ostream &plotgrammar_stream() {
+    if (is_stdout()) {
+      return std::cout;
+    }
 
+    assert(!plotgrammar_stream_);
+    plotgrammar_stream_ = new std::ofstream(plot_grammar_file.c_str());
+    plotgrammar_stream_->exceptions(std::ios_base::badbit |
+                          std::ios_base::failbit | std::ios_base::eofbit);
+    return *plotgrammar_stream_;
+  }
   bool check();
 };
 

--- a/src/options.hh
+++ b/src/options.hh
@@ -57,7 +57,7 @@ struct Options {
       pareto(0), multiDimPareto(false), cutoff(65),
       float_acc(0),
       specialization(0), step_option(0),
-      plot_grammar(false), plotgrammar_stream_(NULL) {
+      plot_grammar(0), plotgrammar_stream_(NULL) {
   }
 
 
@@ -188,7 +188,7 @@ struct Options {
   }
 
   std::string plot_grammar_file;
-  bool plot_grammar;
+  int plot_grammar;
   std::ostream *plotgrammar_stream_;
   std::ostream &plotgrammar_stream() {
     if (is_stdout()) {
@@ -201,6 +201,7 @@ struct Options {
                           std::ios_base::failbit | std::ios_base::eofbit);
     return *plotgrammar_stream_;
   }
+
   bool check();
 };
 

--- a/src/specialize_grammar/create_specialized_grammar.cc
+++ b/src/specialize_grammar/create_specialized_grammar.cc
@@ -1416,7 +1416,8 @@ std::list<Statement::Base*>* SpecializeGrammar::CreateSpecializedGrammar::
   std::list<Fn_Arg::Base*> originalArguments =
     this->algebraFunctionInfoAttribute->getAlgebraFunctionArguments();
   assert(originalAlgebraFunctionName != NULL);
-  assert(originalArguments != NULL);
+  // not a pointer, therefore cannot be NULL!
+  // assert(originalArguments != NULL);
 
 
   std::list<Statement::Base*>* result = new std::list<Statement::Base*>();
@@ -1705,7 +1706,8 @@ std::list<Statement::Base*>* SpecializeGrammar::CreateSpecializedGrammar::
   std::list<Fn_Arg::Base*> originalArguments =
     algebraFunctionInfoAttribute->getAlgebraFunctionArguments();
   assert(originalAlgebraFunctionName != NULL);
-  assert(originalArguments != NULL);
+  // not a pointer, therefore cannot be NULL!
+  // assert(originalArguments != NULL);
 
 
   // Before we start, we need to order all arguments and create

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -1659,6 +1659,13 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
       unsigned int childID = (*alt)->to_dot(nodeID, out);
       out << "node_" << thisID << " -> node_" << childID << ";\n";
     }
+    if (this->eval_fn != NULL) {
+      unsigned int choiceID = (unsigned int)((*nodeID)++);
+      out << "node_" << choiceID << " [ label=" << *this->eval_fn
+          << ", fontcolor=\"purple\" , shape=none ];\n";
+      out << "node_" << thisID << " -> node_" << choiceID
+          << " [ arrowhead=none, color=\"purple\" ];\n";
+    }
   }
   return thisID;
 }

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -1650,6 +1650,9 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
     if (this == axiom) {
       out << ", penwidth=3";
     }
+    if (!this->tabulated) {
+      out << ", style=\"dotted\"";
+    }
     out << " ];\n";
     for (std::list<Alt::Base*>::const_iterator alt = this->alts.begin();
          alt != this->alts.end(); ++alt) {

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -1625,24 +1625,37 @@ bool Symbol::Terminal::isPredefinedTerminalParser() {
 
 // the following functions produce graphViz code to represent the grammar
 unsigned int Symbol::Base::to_dot(unsigned int *nodeID, std::ostream &out,
-                                  bool is_rhs, Symbol::NT *axiom) {
+        bool is_rhs, Symbol::NT *axiom, int plot_grammar) {
   unsigned int thisID = (unsigned int)((*nodeID)++);
   out << "node_" << thisID << " [ label=<<table border='0'><tr>";
-  to_dot_indices(this->left_indices, out);
-  out << "<td>" << *this->name << "</td>";
-  to_dot_indices(this->right_indices, out);
-  out << "</tr></table>>";
+  if (plot_grammar > 1) {
+      to_dot_indices(this->left_indices, out);
+      out << "<td>" << *this->name << "</td>";
+      to_dot_indices(this->right_indices, out);
+      out << "</tr></table>>";
+  } else {
+      out << "<td>" << *this->name << "</td></tr></table>>";
+  }
   return thisID;
 }
 unsigned int Symbol::Terminal::to_dot(unsigned int *nodeID, std::ostream &out,
-                                      bool is_rhs, Symbol::NT *axiom) {
-  unsigned int thisID = Symbol::Base::to_dot(nodeID, out, is_rhs, axiom);
+                                      bool is_rhs, Symbol::NT *axiom,
+                                      int plot_grammar) {
+  unsigned int thisID = Symbol::Base::to_dot(nodeID, out, is_rhs, axiom,
+          plot_grammar);
   out << ", color=\"blue\", fontcolor=\"blue\" ];\n";
   return thisID;
 }
 unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
-                                bool is_rhs, Symbol::NT *axiom) {
-  unsigned int thisID = Symbol::Base::to_dot(nodeID, out, is_rhs, axiom);
+                                bool is_rhs, Symbol::NT *axiom,
+                                int plot_grammar) {
+  unsigned int thisID = Symbol::Base::to_dot(nodeID, out, is_rhs, axiom,
+           plot_grammar);
+  unsigned int pre_ID = thisID;
+  unsigned int choiceID;
+  unsigned int depth = 1;
+  unsigned int *res = (unsigned int *) malloc(2 * sizeof(int));
+  std::string rank = "";
   out << ", color=\"black\"";
   if (!is_rhs) {
     // a non-terminal "calling" productions, i.e. on the left hand side
@@ -1654,19 +1667,73 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
       out << ", style=\"dotted\"";
     }
     out << " ];\n";
+
     for (std::list<Alt::Base*>::const_iterator alt = this->alts.begin();
          alt != this->alts.end(); ++alt) {
-      unsigned int childID = (*alt)->to_dot(nodeID, out);
-      out << "node_" << thisID << " -> node_" << childID << ";\n";
+      unsigned int d = 1;
+      res = (*alt)->to_dot(nodeID, out, plot_grammar, d);
+      unsigned int childID = res[0];
+      d = res[1];
+      if (d > depth) {
+          depth = d;
+      }
+      if (pre_ID != thisID) {
+          out << "node_" << pre_ID << "_" << childID << "[ label=<<table "
+                  "border='0'><tr><td><font point-size='30'>|</font></td>"
+                  "</tr></table>>, shape=plaintext];\n";
+          out << "node_" << pre_ID << " -> node_" << pre_ID << "_" << childID <<
+                      "[style= invis];\n";
+          out << "node_" << pre_ID << "_" << childID << " -> node_" <<
+                  childID << "[style= invis];\n";
+      } else {
+          out << "node_"  << pre_ID << "_" << childID << "[ label=<<table "
+                  "border='0'><tr><td><font point-size='30'>&rarr;</font>"
+                  "</td></tr></table>>, shape=plaintext];\n";
+          out << "node_" << pre_ID << " -> node_" << pre_ID << "_" <<
+                  childID << "[style= invis, weight=99];\n";
+          out << "node_" << pre_ID << "_" << childID << " -> node_" <<
+                  childID << "[style= invis];\n";
+      }
+      rank =  rank + "node_" + std::to_string(pre_ID) + "_" +
+              std::to_string(childID) + " " + "node_" +
+              std::to_string(childID) + " ";
+      pre_ID = childID;
     }
+
     if (this->eval_fn != NULL) {
-      unsigned int choiceID = (unsigned int)((*nodeID)++);
-      out << "node_" << choiceID << " [ label=" << *this->eval_fn
-          << ", fontcolor=\"purple\" , shape=none ];\n";
-      out << "node_" << thisID << " -> node_" << choiceID
-          << " [ arrowhead=none, color=\"purple\" ];\n";
+          choiceID = (unsigned int)((*nodeID)++);
+          out << "node_" << choiceID << " [ label=" << *this->eval_fn
+              << ", fontcolor=\"purple\" , shape=none ];\n";
+          out << "node_" << thisID << " -> node_" << choiceID
+              << " [ arrowhead=none, color=\"purple\" , weight=99];\n";
+        } else {
+          choiceID = (unsigned int)((*nodeID)++);
+          out << "node_" << choiceID << " [ label=h_" << thisID
+              << ", fontcolor=\"purple\" , shape=none , style=invis];\n";
+          out << "node_" << thisID << " -> node_" << choiceID
+              << " [ arrowhead=none, color=\"purple\" , style=invis, "
+                      "weight=99];\n";
+        }
+
+    for ( unsigned int i = 1; i < depth; i++ ) {
+        unsigned int childID = (unsigned int)((*nodeID)++);
+        if (plot_grammar > 1) {
+            out << "node_" << childID << "[label=<<table border='0'><tr>";
+            to_dot_indices(this->left_indices, out);
+            out << "<td>" << *this->name << "</td>";
+            to_dot_indices(this->right_indices, out);
+            out << "</tr></table>>, shape=\"box\", style=invis];\n";
+        } else {
+            out << "node_" << childID << "[label = " << *this->name <<
+                    ", shape=\"box\", style=invis];\n";
+        }
+        out << "node_" << choiceID << " -> " << "node_" << childID <<
+               "[weight = 99, style = invis];\n";;
+        choiceID = childID;
     }
+    out << "{ rank=same node_" << thisID << " " << rank << "}\n";
   }
+  free(res);
   return thisID;
 }
 // END functions produce graphViz code to represent the grammar

--- a/src/symbol.hh
+++ b/src/symbol.hh
@@ -250,7 +250,8 @@ class Base {
     virtual bool multi_detect_loop();
 
     virtual unsigned int to_dot(unsigned int *nodeID, std::ostream &out,
-                                bool is_rhs, Symbol::NT *axiom);
+                                bool is_rhs, Symbol::NT *axiom,
+                                int plot_grammar);
 };
 
 
@@ -309,7 +310,7 @@ class Terminal : public Base {
     void setPredefinedTerminalParser(bool isPredefined);
     bool isPredefinedTerminalParser();
     unsigned int to_dot(unsigned int *nodeID, std::ostream &out,
-                        bool is_rhs, Symbol::NT *axiom);
+                        bool is_rhs, Symbol::NT *axiom, int plot_grammar);
 };
 
 
@@ -514,7 +515,7 @@ class NT : public Base {
       return ntargs_;
     }
     unsigned int to_dot(unsigned int *nodeID, std::ostream &out,
-                        bool is_rhs, Symbol::NT *axiom);
+                        bool is_rhs, Symbol::NT *axiom, int plot_grammar);
 };
 
 

--- a/src/symbol.hh
+++ b/src/symbol.hh
@@ -248,6 +248,9 @@ class Base {
     virtual bool multi_detect_loop(const Yield::Multi &left,
                                    const Yield::Multi &right, Symbol::NT *nt);
     virtual bool multi_detect_loop();
+
+    virtual unsigned int to_dot(unsigned int *nodeID, std::ostream &out,
+                                bool is_rhs, Symbol::NT *axiom);
 };
 
 
@@ -305,6 +308,8 @@ class Terminal : public Base {
 
     void setPredefinedTerminalParser(bool isPredefined);
     bool isPredefinedTerminalParser();
+    unsigned int to_dot(unsigned int *nodeID, std::ostream &out,
+                        bool is_rhs, Symbol::NT *axiom);
 };
 
 
@@ -508,6 +513,8 @@ class NT : public Base {
     const std::list<Para_Decl::Base*> &ntargs() const {
       return ntargs_;
     }
+    unsigned int to_dot(unsigned int *nodeID, std::ostream &out,
+                        bool is_rhs, Symbol::NT *axiom);
 };
 
 

--- a/src/type/base.cc
+++ b/src/type/base.cc
@@ -24,6 +24,7 @@
 #include "base.hh"
 
 #include <cstdlib>
+#include <string>
 
 Type::Base::~Base() {}
 
@@ -67,4 +68,27 @@ Type::Base *Type::Base::component() {
 
 Type::Base *Type::Base::deref() {
   return this;
+}
+
+// replaces from with to in str
+void replaceAll(std::string& str, const std::string& from,
+                const std::string& to) {
+  if (from.empty())
+    return;
+  size_t start_pos = 0;
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+    // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    start_pos += to.length();
+  }
+}
+
+// graphViz compatible text representation of datatype
+void Type::Base::to_dot(std::ostream &out) {
+  std::ostringstream dtype_stream;
+  this->put(dtype_stream);
+  std::string dtype = dtype_stream.str();
+  replaceAll(dtype, std::string("<"), std::string("&lt;"));
+  replaceAll(dtype, std::string(">"), std::string("&gt;"));
+  out << dtype;
 }

--- a/src/type/base.hh
+++ b/src/type/base.hh
@@ -25,6 +25,8 @@
 #define SRC_TYPE_BASE_HH_
 
 #include <cassert>
+#include <sstream>
+#include <string>
 
 #include "../loc.hh"
 #include "../printer_fwd.hh"
@@ -101,6 +103,7 @@ class Base {
     virtual Base *deref();
 
     virtual void print(Printer::Base &s) const = 0;
+    void to_dot(std::ostream &out);
 };
 
 
@@ -111,5 +114,7 @@ inline std::ostream & operator<< (std::ostream &s, const Base &p) {
 
 }  // namespace Type
 
+void replaceAll(std::string& str, const std::string& from,
+  const std::string& to);
 
 #endif  // SRC_TYPE_BASE_HH_

--- a/testdata/modtest/multi_plot_grammar.cc
+++ b/testdata/modtest/multi_plot_grammar.cc
@@ -1,0 +1,88 @@
+// Copyright 2022 stefan.m.janssen@gmail.com
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cassert>
+
+#include "../../src/driver.hh"
+#include "../../src/log.hh"
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Call " << *argv << " *.gap-file\n";
+    return 1;
+  }
+
+  std::ostringstream o;
+  Log log;
+  log.set_debug(false);
+  log.set_ostream(o);
+
+  Driver driver;
+
+  // === front
+  // set the file name of the gap-source-code
+  std::string filename(argv[1]);
+  driver.setFilename(filename);
+
+  // parses the input file and builds the AST
+  driver.parse();
+  if (driver.is_failing()) {
+    return 4;
+  }
+
+  // simply gets the selected grammar, which is either the
+  // grammar that occurred first in the source code or is the
+  // one that was named in the parameters on the command line
+  Grammar *grammar = driver.ast.grammar();
+  // Now check the semantic, which does more than the function
+  // name suggests. The semantic check is embedded in the algorithm
+  // that links the grammar graph together, and computes yield-sizes.
+  // If the method returns false, there are some semantic errors,
+  // which leads to the end of the compilation process.
+  bool r = grammar->check_semantic();
+  if (!r) {
+    return 2;
+  }
+
+  // set approx table design
+  grammar->approx_table_conf();
+
+  // find what type of input is read
+  // chars, sequence of ints etc.
+  driver.ast.derive_temp_alphabet();
+
+  try {
+    r = driver.ast.check_signature();
+    if (!r) {
+      return 3;
+    }
+  } catch (LogThreshException) {
+    return 9;
+  }
+
+  if (driver.ast.first_instance == NULL) {
+    return 11;
+  }
+  r = driver.ast.check_instances(driver.ast.first_instance);
+  if (!r)
+    return 10;
+
+  // apply this to identify standard functions like Min, Max, Exp etc.
+  driver.ast.derive_roles();
+
+
+  // ------------- back ------------
+  grammar->init_list_sizes();
+
+  grammar->init_indices();
+  grammar->init_decls();
+  // for cyk (ordering of NT for parsing, see page 101 of the thesis)
+  grammar->dep_analysis();
+
+  unsigned int nodeID = 1;
+  int plot_level = 1;
+  grammar->to_dot(&nodeID, std::cout, plot_level);
+  return 0;
+}

--- a/testdata/modtest/multi_plot_grammar_full.cc
+++ b/testdata/modtest/multi_plot_grammar_full.cc
@@ -1,0 +1,88 @@
+// Copyright 2022 stefan.m.janssen@gmail.com
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cassert>
+
+#include "../../src/driver.hh"
+#include "../../src/log.hh"
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Call " << *argv << " *.gap-file\n";
+    return 1;
+  }
+
+  std::ostringstream o;
+  Log log;
+  log.set_debug(false);
+  log.set_ostream(o);
+
+  Driver driver;
+
+  // === front
+  // set the file name of the gap-source-code
+  std::string filename(argv[1]);
+  driver.setFilename(filename);
+
+  // parses the input file and builds the AST
+  driver.parse();
+  if (driver.is_failing()) {
+    return 4;
+  }
+
+  // simply gets the selected grammar, which is either the
+  // grammar that occurred first in the source code or is the
+  // one that was named in the parameters on the command line
+  Grammar *grammar = driver.ast.grammar();
+  // Now check the semantic, which does more than the function
+  // name suggests. The semantic check is embedded in the algorithm
+  // that links the grammar graph together, and computes yield-sizes.
+  // If the method returns false, there are some semantic errors,
+  // which leads to the end of the compilation process.
+  bool r = grammar->check_semantic();
+  if (!r) {
+    return 2;
+  }
+
+  // set approx table design
+  grammar->approx_table_conf();
+
+  // find what type of input is read
+  // chars, sequence of ints etc.
+  driver.ast.derive_temp_alphabet();
+
+  try {
+    r = driver.ast.check_signature();
+    if (!r) {
+      return 3;
+    }
+  } catch (LogThreshException) {
+    return 9;
+  }
+
+  if (driver.ast.first_instance == NULL) {
+    return 11;
+  }
+  r = driver.ast.check_instances(driver.ast.first_instance);
+  if (!r)
+    return 10;
+
+  // apply this to identify standard functions like Min, Max, Exp etc.
+  driver.ast.derive_roles();
+
+
+  // ------------- back ------------
+  grammar->init_list_sizes();
+
+  grammar->init_indices();
+  grammar->init_decls();
+  // for cyk (ordering of NT for parsing, see page 101 of the thesis)
+  grammar->dep_analysis();
+
+  unsigned int nodeID = 1;
+  int plot_level = 99;
+  grammar->to_dot(&nodeID, std::cout, plot_level);
+  return 0;
+}


### PR DESCRIPTION
This PR adds a novel feature. With `--plot-grammar`, the user can request the generation of a out.dot file that holds a rudimentary graph representing the grammar. This is handy if the grammar is modified by the compiler.

This is not yet complete! Missing:
  - [x] handling of multi-track
  - [x] annotation of semantic filtering
  - [x] unit tests
  - [x] index hacks, aka implicit indices: 8-sided polygons for nodes + red bold explicit indices
  - [x] tabulation: non-terminals NOT resulting in DP-tables are plotted in dotted rectangles
  - [x] multi-filter
  - [x] evaluation function