### PR TITLE
swap order

### DIFF
--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1862,12 +1862,6 @@ void Alt::Simple::codegen(AST &ast) {
     }
     stmts = &guards->then;
   }
-  init_filter_guards(ast);
-  if (filter_guards) {
-    stmts->push_back(filter_guards);
-    stmts = &filter_guards->then;
-    ret_decl_empty_block(filter_guards);
-  }
 
 
         // answer_list is always set when return type is a list
@@ -1905,6 +1899,13 @@ void Alt::Simple::codegen(AST &ast) {
                 statements.push_back(mark);
             }
         }
+
+  init_filter_guards(ast);
+  if (filter_guards) {
+    stmts->push_back(filter_guards);
+    stmts = &filter_guards->then;
+    ret_decl_empty_block(filter_guards);
+  }
 
   if (!loops.empty() && !has_index_overlay()) {
     std::list<Statement::For*> *l = &loops;

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1826,6 +1826,28 @@ std::list<Statement::Base*> *Alt::Simple::insert_index_stmts(
   return ret;
 }
 
+std::list<Statement::Base*> *Alt::Simple::add_filter_guards(AST &ast, std::list<Statement::Base*> *stmts, Statement::If *filter_guards) {
+  if (filter_guards) {
+    stmts->push_back(filter_guards);
+    stmts = &filter_guards->then;
+    ret_decl_empty_block(filter_guards);
+  }
+  return stmts;
+}
+std::list<Statement::Base*> *Alt::Simple::add_for_loops(std::list<Statement::Base*> *stmts, std::list<Statement::For *> loops, bool has_index_overlay) {
+  if (!loops.empty() && !has_index_overlay) {
+    std::list<Statement::For*> *l = &loops;
+    /*
+    if (has_index_overlay()) {
+      l = &index_overlay.front()->loops;
+    }
+    */
+    stmts->push_back(l->front());
+    Statement::For *loop = nest_for_loops(l->begin(), l->end());
+    stmts = &loop->statements;
+  }
+  return stmts;
+}
 
 void Alt::Simple::codegen(AST &ast) {
   // std::cout << "-----------Simple IN" << std::endl;
@@ -1863,6 +1885,7 @@ void Alt::Simple::codegen(AST &ast) {
     stmts = &guards->then;
   }
 
+  init_filter_guards(ast);
 
         // answer_list is always set when return type is a list
         // see symbol set_ret_decl_rhs
@@ -1900,24 +1923,12 @@ void Alt::Simple::codegen(AST &ast) {
             }
         }
 
-  init_filter_guards(ast);
-  if (filter_guards) {
-    stmts->push_back(filter_guards);
-    stmts = &filter_guards->then;
-    ret_decl_empty_block(filter_guards);
-  }
+  // add filter_guards
+  stmts = add_filter_guards(ast, stmts, filter_guards);
 
-  if (!loops.empty() && !has_index_overlay()) {
-    std::list<Statement::For*> *l = &loops;
-    /*
-    if (has_index_overlay()) {
-    l = &index_overlay.front()->loops;
-    }
-    */
-    stmts->push_back(l->front());
-    Statement::For *loop = nest_for_loops(l->begin(), l->end());
-    stmts = &loop->statements;
-  }
+  // add for loops for moving boundaries
+  stmts = add_for_loops(stmts, loops, has_index_overlay());
+
   add_subopt_guards(stmts, ast);
 
   stmts = insert_index_stmts(stmts);

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1826,7 +1826,9 @@ std::list<Statement::Base*> *Alt::Simple::insert_index_stmts(
   return ret;
 }
 
-std::list<Statement::Base*> *Alt::Simple::add_filter_guards(AST &ast, std::list<Statement::Base*> *stmts, Statement::If *filter_guards) {
+std::list<Statement::Base*> *Alt::Simple::add_filter_guards(
+    std::list<Statement::Base*> *stmts,
+    Statement::If *filter_guards) {
   if (filter_guards) {
     stmts->push_back(filter_guards);
     stmts = &filter_guards->then;
@@ -1834,7 +1836,10 @@ std::list<Statement::Base*> *Alt::Simple::add_filter_guards(AST &ast, std::list<
   }
   return stmts;
 }
-std::list<Statement::Base*> *Alt::Simple::add_for_loops(std::list<Statement::Base*> *stmts, std::list<Statement::For *> loops, bool has_index_overlay) {
+std::list<Statement::Base*> *Alt::Simple::add_for_loops(
+    std::list<Statement::Base*> *stmts,
+    std::list<Statement::For *> loops,
+    bool has_index_overlay) {
   if (!loops.empty() && !has_index_overlay) {
     std::list<Statement::For*> *l = &loops;
     /*

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1929,7 +1929,7 @@ void Alt::Simple::codegen(AST &ast) {
         }
 
   // add filter_guards
-  stmts = add_filter_guards(ast, stmts, filter_guards);
+  stmts = add_filter_guards(stmts, filter_guards);
 
   // add for loops for moving boundaries
   stmts = add_for_loops(stmts, loops, has_index_overlay());

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -441,6 +441,8 @@ class Simple : public Base {
   void init_multi_ys();
 
  private:
+  std::list<Statement::Base*> *add_filter_guards(AST &ast, std::list<Statement::Base*> *stmts, Statement::If *filter_guards);
+  std::list<Statement::Base*> *add_for_loops(std::list<Statement::Base*> *stmts, std::list<Statement::For *> loops, bool has_index_overlay);
   void sum_rhs(
     Yield::Multi &y, std::list<Fn_Arg::Base*>::const_iterator i,
     const std::list<Fn_Arg::Base*>::const_iterator &end) const;

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -441,8 +441,13 @@ class Simple : public Base {
   void init_multi_ys();
 
  private:
-  std::list<Statement::Base*> *add_filter_guards(AST &ast, std::list<Statement::Base*> *stmts, Statement::If *filter_guards);
-  std::list<Statement::Base*> *add_for_loops(std::list<Statement::Base*> *stmts, std::list<Statement::For *> loops, bool has_index_overlay);
+  std::list<Statement::Base*> *add_filter_guards(
+    std::list<Statement::Base*> *stmts,
+    Statement::If *filter_guards);
+  std::list<Statement::Base*> *add_for_loops(
+    std::list<Statement::Base*> *stmts,
+    std::list<Statement::For *> loops,
+    bool has_index_overlay);
   void sum_rhs(
     Yield::Multi &y, std::list<Fn_Arg::Base*>::const_iterator i,
     const std::list<Fn_Arg::Base*>::const_iterator &end) const;


### PR DESCRIPTION
moving adding filter_guards and for-loops in alt code generation into separate helper functions, such that outside code generation can easier call these functions in reverse order