### PR TITLE
Backward

### DIFF
--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -1128,7 +1128,18 @@ void Printer::Cpp::print(const Statement::Table_Decl &t) {
 
   stream << indent() << ptype << " newsize = size(";
   stream << ");" << endl;
-  stream << indent() << "array.resize(newsize);" << endl;
+
+  /* ==== for differential backtracking ====
+   * We not only need to store the forward results, but also track the
+   * incoming contributions per alternative production rule.
+   * Furthermore, in the backward pass, we want to store its result
+   * as well. Thus, we need larger storage, namely:
+   * newsize * (1 + num_alternatives + 1)
+   */
+  stream << indent() << "unsigned int num_alternatives = "
+		 << t.nt().alts.size() << ";" << endl;
+  stream << indent() << "array.resize(newsize * (1 + num_alternatives + 1));"
+		 << endl;
   if (!cyk) {
     stream << indent() << "tabulated.clear();" << endl;
     stream << indent() << "tabulated.resize(newsize);" << endl;
@@ -1154,7 +1165,12 @@ void Printer::Cpp::print(const Statement::Table_Decl &t) {
 
   stream << t.fn_get_tab() << endl;
 
-  stream << t.fn_tab();
+  stream << t.fn_tab() << endl;
+
+  /* ==== for differential backtracking ====
+   * create a function that tracks incoming contributions
+   */
+  stream << t.fn_track();
 
   dec_indent();
   stream << indent() << "};" << endl;

--- a/src/statement/table_decl.cc
+++ b/src/statement/table_decl.cc
@@ -36,6 +36,7 @@ Table_Decl::Table_Decl(
         bool c,
         Fn_Def *fn_is_tab,
         Fn_Def *fn_tab,
+		Fn_Def *fn_track,
         Fn_Def *fn_get_tab,
         Fn_Def *fn_size,
         const std::list<Statement::Var_Decl*> &ns
@@ -48,6 +49,7 @@ Table_Decl::Table_Decl(
   fn_is_tab_(fn_is_tab),
   fn_untab_(0),
   fn_tab_(fn_tab),
+  fn_track_(fn_track),
   fn_get_tab_(fn_get_tab),
   fn_size_(fn_size),
   ns_(ns) {

--- a/src/statement/table_decl.hh
+++ b/src/statement/table_decl.hh
@@ -48,6 +48,7 @@ class Table_Decl : public Base {
   Fn_Def *fn_is_tab_;
   Fn_Def *fn_untab_;
   Fn_Def *fn_tab_;
+  Fn_Def *fn_track_;
   Fn_Def *fn_get_tab_;
   Fn_Def *fn_size_;
 
@@ -60,6 +61,7 @@ class Table_Decl : public Base {
     bool c,
     Fn_Def *fn_is_tab,
     Fn_Def *fn_tab,
+	Fn_Def *fn_track,
     Fn_Def *fn_get_tab,
     Fn_Def *fn_size,
     const std::list<Statement::Var_Decl*> &ns);
@@ -76,6 +78,7 @@ class Table_Decl : public Base {
   const Fn_Def &fn_untab() const { assert(fn_untab_); return *fn_untab_; }
   void set_fn_untab(Fn_Def *d) { fn_untab_ = d; }
   const Fn_Def &fn_tab() const { return *fn_tab_; }
+  const Fn_Def &fn_track() const { return *fn_track_; }
   const Fn_Def &fn_get_tab() const { return *fn_get_tab_; }
   const Fn_Def &fn_size() const { return *fn_size_; }
 

--- a/src/tablegen.hh
+++ b/src/tablegen.hh
@@ -83,7 +83,7 @@ class Tablegen {
 
     Fn_Def *gen_is_tab();
     Fn_Def *gen_untab();
-    Fn_Def *gen_tab();
+    Fn_Def *gen_tab(bool for_tracking = false);
     Fn_Def *gen_get_tab();
     Fn_Def *gen_size();
 


### PR DESCRIPTION
This is a quick and dirty attempt to compute 1st and 2nd derivatives.

- increase table capacity to additionally store `q`'s `e`'s from backward pass
  - will this work in window mode?
  - what about non tabulated NTs?
  - check in Symbol::NT::set_ret_decl_rhs if other cases also need a "track" call
  - can we have situations in which same q edge is used multiple times but with different weights? `ntX = add(ntA, ntB, ntC)` such that moving bundary between `ntB and btC` with same `ntA` is used?