### PR TITLE
Fix outside plusminus

### DIFF
--- a/src/alt.cc
+++ b/src/alt.cc
@@ -3563,7 +3563,7 @@ Expr::Base *Alt::Simple::get_next_var_right2left(Expr::Base *left_index,
   }
 
   if (ys_lefts->low() == ys_lefts->high()) {
-    return innermost_left_index->plus(ys_lefts->low());
+    return innermost_left_index->minus(ys_lefts->low());
   }
 
   // variable yield size


### PR DESCRIPTION
Indices for terminals and non-terminals left of the outside-NT were incremented by yield size, but they have to be decremented. Otherwise, we have negative sub-word intervals!