### PR TITLE
Speed up calculations in energy functions

### DIFF
--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -429,12 +429,12 @@ double mk_pf(double energy) {
 
 static double get_scale_value(int subword_size) {
   // precalculate the first 10000 scale values
-  
+
   static bool init = false;
   static const double MEAN_NRG = -0.1843;
   static double lookup[LOOKUP_SIZE];
   static double mean_scale;
-  
+
   if (!init) {
     // temperature can be adjusted with the -T flag at runtime
     mean_scale = exp(-1.0 * MEAN_NRG /

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -501,7 +501,7 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder) {
 
   if ((pos <= leftBorder) || (x <= leftBorder))
     return leftBorder;
-  
+
   rsize nongaps = 0;
 
   do {
@@ -1157,16 +1157,18 @@ int ml_mismatch_energy(const char *s, rsize i, rsize j) {
 static rsize getNext(const char *s, rsize pos, rsize steps,
                      rsize rightBorder, unsigned currRow, unsigned maxRows) {
   assert(steps > 0);
-  rsize nongaps = 0;
+
   rsize x = pos + 1;
   if (x >= rightBorder)
     return rightBorder;
+
+  rsize nongaps = 0;
 
   static bool init = false;
   static rsize *lookup;
   static unsigned seqLen;
   static unsigned triu;
-  
+
   if (!init) {
     seqLen = strlen(s);
     triu = (seqLen * (seqLen + 1)) / 2 + 1;
@@ -1176,8 +1178,9 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
   }
 
   unsigned long index = (steps - 1) * triu * maxRows + triu * currRow +
-                        pos * seqLen + rightBorder - ((pos * (pos + 1)) / 2);
-  
+                        pos * seqLen + rightBorder -
+                        ((pos * (pos + 1)) / 2);
+
   if (lookup[index]) {
     return lookup[index];
   }
@@ -1190,7 +1193,7 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
       return x - 1;
     }
   } while (nongaps < steps && ++x < rightBorder);
-  
+
   lookup[index] = x;
 
   return x;
@@ -1204,9 +1207,9 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
 
   if ((pos <= leftBorder) || (x <= leftBorder))
     return leftBorder;
-  
+
   rsize nongaps = 0;
-  
+
   static bool init = false;
   static rsize *lookup;
   static unsigned seqLen;
@@ -1221,7 +1224,8 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
   }
 
   unsigned long index = triu * (steps - 1) * maxRows + currRow * triu +
-                        leftBorder * seqLen + pos - ((leftBorder * (leftBorder + 1)) / 2);
+                        leftBorder * seqLen + pos -
+                        ((leftBorder * (leftBorder + 1)) / 2);
 
   if (lookup[index]) {
     return lookup[index];
@@ -1441,7 +1445,8 @@ int il_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
     }
   }
 
-  return il_ent(sl+sr) + il_stack(s, i, k, l, j, currRow, maxRows) + il_asym(sl, sr);
+  return il_ent(sl+sr) + il_stack(s, i, k, l, j, currRow, maxRows) +
+         il_asym(sl, sr);
 }
 
 int bl_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
@@ -1454,13 +1459,15 @@ int bl_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
   if (size == 0) {
     int closingBP = bp_index(s[i], s[j]);
     // Note, basepair is reversed to preserver 5'-3' order
-    int enclosedBP = bp_index(s[getPrev(s, j, 1, Xright, currRow, maxRows)], s[l+1]);
+    int enclosedBP = bp_index(s[getPrev(s, j, 1, Xright, currRow, maxRows)],
+                              s[l+1]);
     return P->stack[closingBP][enclosedBP];
   }
   if (size == 1) {
     int closingBP = bp_index(s[i], s[j]);
     // Note, basepair is reversed to preserver 5'-3' order
-    int enclosedBP = bp_index(s[getPrev(s, j, 1, Xright, currRow, maxRows)], s[l+1]);
+    int enclosedBP = bp_index(s[getPrev(s, j, 1, Xright, currRow, maxRows)],
+                              s[l+1]);
     return bl_ent(size) + P->stack[closingBP][enclosedBP];
   }
   if (size > 1) {
@@ -1482,13 +1489,15 @@ int br_energy(const char *s, rsize i, rsize k, rsize l, rsize j, rsize Xleft,
   if (size == 0) {
     int closingBP = bp_index(s[i], s[j]);
     // Note, basepair is reversed to preserver 5'-3' order
-    int enclosedBP = bp_index(s[k-1], s[getNext(s, i, 1, Xleft, currRow, maxRows)]);
+    int enclosedBP = bp_index(s[k-1],
+                              s[getNext(s, i, 1, Xleft, currRow, maxRows)]);
     return P->stack[closingBP][enclosedBP];
   }
   if (size == 1) {
     int closingBP = bp_index(s[i], s[j]);
     // Note, basepair is reversed to preserver 5'-3' order
-    int enclosedBP = bp_index(s[k-1], s[getNext(s, i, 1, Xleft, currRow, maxRows)]);
+    int enclosedBP = bp_index(s[k-1],
+                              s[getNext(s, i, 1, Xleft, currRow, maxRows)]);
     return bl_ent(size) + P->stack[closingBP][enclosedBP];
   }
   if (size > 1) {

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1158,7 +1158,7 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
                      rsize rightBorder, unsigned currRow, unsigned maxRows) {
   assert(steps > 0);
   rsize nongaps = 0;
-  rsize x = pos+1;
+  rsize x = pos + 1;
   if (x >= rightBorder)
     return rightBorder;
 
@@ -1175,8 +1175,8 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
     init = true;
   }
 
-  unsigned long index = triu * steps * currRow + pos * seqLen +
-                        rightBorder - ((pos * (pos + 1)) / 2);
+  unsigned long index = (steps - 1) * triu * maxRows + triu * currRow +
+                        pos * seqLen + rightBorder - ((pos * (pos + 1)) / 2);
   
   if (lookup[index]) {
     return lookup[index];
@@ -1185,8 +1185,10 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
   do {
     if (s[x] != GAP_BASE)
       ++nongaps;
-    if (s[x] == SEPARATOR_BASE)
-      return x-1;
+    if (s[x] == SEPARATOR_BASE) {
+      lookup[index] = x - 1;
+      return x - 1;
+    }
   } while (nongaps < steps && ++x < rightBorder);
   
   lookup[index] = x;
@@ -1198,7 +1200,7 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
                      unsigned currRow, unsigned maxRows) {
   assert(pos >= 0);
   assert(steps > 0);
-  rsize x = pos-1;
+  rsize x = pos - 1;
 
   if ((pos <= leftBorder) || (x <= leftBorder))
     return leftBorder;
@@ -1218,8 +1220,8 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
     init = true;
   }
 
-  unsigned long index = triu * steps * currRow + leftBorder * seqLen +
-                        pos - ((leftBorder * (leftBorder + 1)) / 2);
+  unsigned long index = triu * (steps - 1) * maxRows + currRow * triu +
+                        leftBorder * seqLen + pos - ((leftBorder * (leftBorder + 1)) / 2);
 
   if (lookup[index]) {
     return lookup[index];
@@ -1228,8 +1230,10 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
   do {
     if (s[x] != GAP_BASE)
       ++nongaps;
-    if (s[x] == SEPARATOR_BASE)
-      return x+1;
+    if (s[x] == SEPARATOR_BASE) {
+      lookup[index] = x + 1;
+      return x + 1;
+    }
   } while (nongaps < steps && --x > leftBorder);
 
   lookup[index] = x;

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1166,7 +1166,7 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
   static rsize *lookup;
   static unsigned seqLen;
   static unsigned triu;
-
+  
   if (!init) {
     seqLen = strlen(s);
     triu = (seqLen * (seqLen + 1)) / 2 + 1;
@@ -1325,19 +1325,6 @@ int hl_energy(const char *s, rsize i, rsize j,
   abort();
 }
 
-int il_stack(const char *s, rsize i, rsize k, rsize l, rsize j,
-             unsigned currRow, unsigned maxRows) {
-  int out_closingBP = bp_index(s[i], s[j]);
-  char out_lbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
-  char out_rbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
-  // Note, basepair and stacking bases are reversed to preserver 5'-3' order
-  int in_closingBP = bp_index(s[l], s[k]);
-  char in_lbase = s[getNext(s, l, 1, j-1, currRow, maxRows)];
-  char in_rbase = s[getPrev(s, k, 1, i+1, currRow, maxRows)];
-  return P->mismatchI[out_closingBP][out_lbase][out_rbase] +
-         P->mismatchI[in_closingBP][in_lbase][in_rbase];
-}
-
 int il11_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
                 unsigned currRow, unsigned maxRows) {
   int closingBP = bp_index(s[i], s[j]);
@@ -1386,6 +1373,19 @@ int il22_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
   char rbase = s[getPrev(s, j, 2, l, currRow, maxRows)];
   char rrbase = s[getPrev(s, j, 1, l, currRow, maxRows)];
   return P->int22[closingBP][enclosedBP][lbase][llbase][rbase][rrbase];
+}
+
+int il_stack(const char *s, rsize i, rsize k, rsize l, rsize j,
+             unsigned currRow, unsigned maxRows) {
+  int out_closingBP = bp_index(s[i], s[j]);
+  char out_lbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
+  char out_rbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
+  // Note, basepair and stacking bases are reversed to preserver 5'-3' order
+  int in_closingBP = bp_index(s[l], s[k]);
+  char in_lbase = s[getNext(s, l, 1, j-1, currRow, maxRows)];
+  char in_rbase = s[getPrev(s, k, 1, i+1, currRow, maxRows)];
+  return P->mismatchI[out_closingBP][out_lbase][out_rbase] +
+         P->mismatchI[in_closingBP][in_lbase][in_rbase];
 }
 
 int il_energy(const char *s, rsize i, rsize k, rsize l, rsize j,

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -56,7 +56,6 @@
 
 static vrna_param_t  *P = 0;
 
-
 void librna_read_param_file(const char *filename) {
   if (P) {
     free(P);
@@ -201,57 +200,6 @@ static size_t ungapRegion(const char *s, rsize i, rsize j, char *ungapped) {
 }
 
 /*
-   Next downstream base is not necessarily the next character in s. There might be one or more GAPs between both. Thus getNext jumps over GAPs to the steps-next non GAP base in s. This is restricted by left and right borders "pos" and "rightBorder".
-   Input is
-     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
-     pos = startpoint of search for right neighboring non-GAP base.
-     steps = sometimes we don't need the direct neighboring base, but also the second, third, ... neighboring non GAP base.
-     rightBorder = last character position to look for right neighboring non-GAP bases.
-*/
-static rsize getNext(const char *s, rsize pos, rsize steps, rsize rightBorder) {
-  assert(steps > 0);
-  rsize nongaps = 0;
-  rsize x = pos+1;
-  if (x >= rightBorder)
-    return rightBorder;
-  do {
-    if (s[x] != GAP_BASE)
-      ++nongaps;
-    if (s[x] == SEPARATOR_BASE)
-      return x-1;
-  } while (nongaps < steps && ++x < rightBorder);
-  return x;
-}
-
-/*
-   Next upstream base is not necessarily the previous character in s. There might be one or more GAPs between both. Thus getNext jumps over GAPs to the step-previous non GAP base in s. This is restricted by left and right borders "leftBorder" and "pos".
-   Input is
-     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
-     pos = last character position to look for left neighboring non-GAP bases.
-     steps = sometimes we don't need the direct neighboring base, but also the second, third, ... neighboring non GAP base.
-     leftBorder = startpoint of search for left neighboring non-GAP base.
-*/
-static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder) {
-  assert(pos >= 0);
-  assert(steps > 0);
-  rsize nongaps = 0;
-  rsize x = pos-1;
-
-  if ((pos <= leftBorder) || (x <= leftBorder))
-    return leftBorder;
-  do {
-    if (s[x] != GAP_BASE)
-      ++nongaps;
-    if (s[x] == SEPARATOR_BASE)
-      return x+1;
-  } while (nongaps < steps && --x > leftBorder);
-
-  return x;
-}
-
-/* ============== END: Alignment functions ================= */
-
-/*
    returns a char pointer, i.e. string, of the decode RNA sequence in letters, after a decoding of the bit encoded chars
            this is a necessary helper function to get energies for special hairpin loop cases, i.e. tri-, tetra- and hexaloops
            due to the strange way the Vienna guys store those energies.
@@ -293,32 +241,6 @@ static int hl_ent(rsize l) {
 }
 
 /*
-   returns stabilizing energy values for the outermost bases of a hairpin loop, which stack onto the closing base pair
-   the outermost bases of the hairpin loop do not form a basepair, thus they are a mismatch
-          . . .
-        .       .
-        .       .
-       i+1     j-1
-          i - j        (i and j form the closing basepair)
-          |   |
-          5'  3'
-   Input is
-     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
-     i = the index (first base of s is 0, second 1, ...) of the 5' partner of the hairpin closing basepair
-     j = the index (first base of s is 0, second 1, ...) of the 3' partner of the hairpin closing basepair
-   mismatchH37 data-arrangement:
-     1. index = bp = code for closing basepair i-j
-     2. index = lbase = code for 5' base i+1 stacking on closing basepair i-j
-     3. index = rbase = code for 3' base j-1 stacking on closing basepair i-j
-*/
-static int hl_stack(const char *s, rsize i, rsize j) {
-  int bp = bp_index(s[i], s[j]);
-  char lbase = s[getNext(s, i, 1, j-1)];
-  char rbase = s[getPrev(s, j, 1, i+1)];
-  return P->mismatchH[bp][lbase][rbase];
-}
-
-/*
    returns the destabilizing energy of all but GC or CG basepairs. This should be applied only on terminal basepairs. It should be better understood as a bonus for CG / GC basepairs.
        X     (X = some closed structure)
      |   |
@@ -346,6 +268,278 @@ int termau_energy(const char *s, rsize i, rsize j) {
 */
 int duplex_energy(void) {
   return P->DuplexInit;
+}
+
+int il_ent(rsize l) {
+  assert(l > 1);
+  if (l > MAXLOOP) {
+      return P->internal_loop[MAXLOOP] + jacobson_stockmayer(l);
+  } else {
+      return P->internal_loop[l];
+  }
+}
+
+/*
+   returns the destabilizing penalty for internal loops with asymmetric sized unpaired loop regions
+   version 1999: currently (12.09.2011) ninio37[2] is 50 and MAX_NINIO is 300
+   version 2004: currently (12.09.2011) ninio37 is 60 and MAX_NINIO is 300
+   Input is
+     sl = size of the 5' unpaired loop region
+     sr = size of the 3' unpaired loop region
+*/
+int il_asym(rsize sl, rsize sr) {
+  int r = abs(sl-sr) * P->ninio[2];
+  if (r < MAX_NINIO) {
+    return r;
+  }
+  return MAX_NINIO;
+}
+
+/*
+   returns destabilizing energy values for an unpaired loop smaller then MAXLOOP bases in a bulge loop
+   for larger loops jacobson_stockmayer is used.
+   currently (12.09.2011) MAXLOOP is 30
+   Input is
+     just the size, i.e. number of bases, of the unpaired loop region: l
+*/
+int bl_ent(rsize l) {
+  assert(l > 0);
+  if (l > MAXLOOP) {
+    return P->bulge[MAXLOOP] + jacobson_stockmayer(l);
+  } else {
+    return P->bulge[l];
+  }
+}
+
+/*
+   returns the stabilizing energy of two successive basepairs forming a stack
+       X          (X = some closed structure)
+     |   |
+   i+1 - j-1      (i+1 and j-1 form the embedded basepair)
+     |   |
+     i - j        (i and j form the closing basepair)
+     |   |
+     5'  3'
+   Input is
+     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
+     i = the index (first base of s is 0, second 1, ...) of the 5' partner of the closing basepair
+     j = the index (first base of s is 0, second 1, ...) of the 3' partner of the closing basepair
+   stack37 data-arrangement:
+     1. index = closingBP = code for closing basepair i-j
+     2. index = enclosedBP = code for enclosed basepair i+1 and j-1. Note, basepair is reversed to preserver 5'-3' order
+*/
+int sr_energy(const char *s, rsize i, rsize j) {
+  int closingBP = bp_index(s[i], s[j]);
+  // Note, basepair is reversed to preserver 5'-3' order
+  int enclosedBP = bp_index(s[j-1], s[i+1]);
+  return P->stack[closingBP][enclosedBP];
+}
+
+/*
+   the same as "sr_energy" but here the input is not relative to the RNA input sequence, but can be any combination of four bases
+   currently used for the coaxial stacking of both stems of a pseudoknot
+*/
+int sr_pk_energy(char a, char b, char c, char d) {
+  int closingBP = bp_index(a, b);
+  // Note, basepair is reversed to preserver 5'-3' order
+  int enclosedBP = bp_index(d, c);
+  return P->stack[closingBP][enclosedBP];
+}
+
+/*
+   returns the energy for initiating a multiloop
+   version 1999: currently (12.09.2011) this value is set to 340
+   version 2004: currently (12.09.2011) this value is set to 930
+*/
+int ml_energy(void) {
+  return P->MLclosing;
+}
+
+/*
+   returns the energy for initiating a stem within a multiloop
+   version 1999: currently (12.09.2011) this value is set to 40
+   version 2004: currently (12.09.2011) this value is set to -90
+*/
+int ul_energy(void) {
+  return P->MLintern[0];
+}
+
+/*
+   returns the energy for one unpaired base, not included into loops (hairpin-, bulge-, internal- loops), but in single stranded stretches next to closed substructures also in multiloops
+   currently (12.09.2011) this value is set to 0
+*/
+int sbase_energy(void) {
+  return 0;
+}
+
+/*
+   same es sbase_energy, but for zero to n bases
+   currently (12.09.2011) this value is set to 0
+*/
+int ss_energy(rsize i, rsize j) {
+  return 0;
+}
+
+
+/*
+   scales the energy value x into a partition function value
+*/
+double mk_pf(double x) {
+  // temperature is defined in ViennaRNA/params/basic.h
+  return exp((-1.0 * x/100.0) / (GASCONST/1000 * (temperature + K0)));
+}
+
+/*
+   returns a partition function bonus for x unpaired bases
+*/
+double scale(int x) {
+  /* mean energy for random sequences: 184.3*length cal */
+  double mean_nrg = -0.1843;
+  double mean_scale = exp(-1.0 * mean_nrg / (GASCONST/1000 * (
+    temperature + K0)));
+
+  return (1.0 / pow(mean_scale, x));
+}
+
+/*
+   support function for dl_energy, for the case when the energy contribution must be independent of the input RNA sequence. This is the case where MacroStates has to use a n-tupel as answer type, where n reflects several possible dangling cases.
+       X          (X = some closed structure)
+     |   |
+     i - j        (i and j form the closing basepair)
+dangle   |        (dangle = 5' dangling base)
+     5'  3'
+   Input is
+     dangle = the code for the dangling base, note: here it is not an index of the input RNA sequence!
+     i = the code for the 5' partner of the closing basepair, note: here it is not an index of the input RNA sequence!
+     j = the code for the 3' partner of the closing basepair, note: here it is not an index of the input RNA sequence!
+*/
+int dl_dangle_dg(enum base_t dangle, enum base_t i, enum base_t j) {
+  int closingBP = bp_index(i, j);
+  int dd = P->dangle5[closingBP][dangle];
+  return (dd > 0) ? 0 : dd;  /* must be <= 0 */
+}
+
+/*
+   symmetric case to dl_dangle_dg
+       X          (X = some closed structure)
+     |   |
+     i - j        (i and j form the closing basepair)
+     |    dangle  (dangle = 3' dangling base)
+     5'  3'
+*/
+int dr_dangle_dg(enum base_t i, enum base_t j, enum base_t dangle) {
+  int closingBP = bp_index(i, j);
+  return P->dangle3[closingBP][dangle];
+  int dd = P->dangle3[closingBP][dangle];
+  return (dd > 0) ? 0 : dd;  /* must be <= 0 */
+}
+
+// added by gsauthof, 2012
+
+static const bool map_base_iupac[5][13] = {
+  /*      {N   , A    , C    , G    , U    , _    , +    , B    , D    ,
+           H    , R    , V    , Y    }, */
+  /* N */ {true, true , true , true , true , true , false, true , true ,
+           true , true , true , true },
+  /* A */ {true, true , false, false, false, false, false, false, true ,
+           true , true , true , false},
+  /* C */ {true, false, true , false, false, false, false, true , false,
+           true , false, true , true },
+  /* G */ {true, false, false, true , false, false, false, true , true ,
+           false, true , true , false},
+  /* U */ {true, false, false, false, true , false, false, true , true ,
+           true , false, false, true },
+};
+
+bool iupac_match(char base, char iupac_base) {
+  assert(base >= 0);
+  assert(base < 6);
+  assert(iupac_base >= 0);
+  assert(iupac_base < 13);
+  return map_base_iupac[base][iupac_base];
+}
+
+#ifndef LOOKUP
+
+/*
+   Next downstream base is not necessarily the next character in s. There might be one or more GAPs between both. Thus getNext jumps over GAPs to the steps-next non GAP base in s. This is restricted by left and right borders "pos" and "rightBorder".
+   Input is
+     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
+     pos = startpoint of search for right neighboring non-GAP base.
+     steps = sometimes we don't need the direct neighboring base, but also the second, third, ... neighboring non GAP base.
+     rightBorder = last character position to look for right neighboring non-GAP bases.
+*/
+static rsize getNext(const char *s, rsize pos, rsize steps, rsize rightBorder) {
+  assert(steps > 0);
+  rsize nongaps = 0;
+  rsize x = pos+1;
+  if (x >= rightBorder)
+    return rightBorder;
+
+  do {
+    if (s[x] != GAP_BASE)
+      ++nongaps;
+    if (s[x] == SEPARATOR_BASE)
+      return x-1;
+  } while (nongaps < steps && ++x < rightBorder);
+
+  return x;
+}
+
+/*
+   Next upstream base is not necessarily the previous character in s. There might be one or more GAPs between both. Thus getNext jumps over GAPs to the step-previous non GAP base in s. This is restricted by left and right borders "leftBorder" and "pos".
+   Input is
+     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
+     pos = last character position to look for left neighboring non-GAP bases.
+     steps = sometimes we don't need the direct neighboring base, but also the second, third, ... neighboring non GAP base.
+     leftBorder = startpoint of search for left neighboring non-GAP base.
+*/
+static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder) {
+  assert(pos >= 0);
+  assert(steps > 0);
+  rsize x = pos-1;
+
+  if ((pos <= leftBorder) || (x <= leftBorder))
+    return leftBorder;
+  
+  rsize nongaps = 0;
+
+  do {
+    if (s[x] != GAP_BASE)
+      ++nongaps;
+    if (s[x] == SEPARATOR_BASE)
+      return x+1;
+  } while (nongaps < steps && --x > leftBorder);
+
+  return x;
+}
+/* ============== END: Alignment functions ================= */
+
+/*
+   returns stabilizing energy values for the outermost bases of a hairpin loop, which stack onto the closing base pair
+   the outermost bases of the hairpin loop do not form a basepair, thus they are a mismatch
+          . . .
+        .       .
+        .       .
+       i+1     j-1
+          i - j        (i and j form the closing basepair)
+          |   |
+          5'  3'
+   Input is
+     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
+     i = the index (first base of s is 0, second 1, ...) of the 5' partner of the hairpin closing basepair
+     j = the index (first base of s is 0, second 1, ...) of the 3' partner of the hairpin closing basepair
+   mismatchH37 data-arrangement:
+     1. index = bp = code for closing basepair i-j
+     2. index = lbase = code for 5' base i+1 stacking on closing basepair i-j
+     3. index = rbase = code for 3' base j-1 stacking on closing basepair i-j
+*/
+
+static int hl_stack(const char *s, rsize i, rsize j) {
+  int bp = bp_index(s[i], s[j]);
+  char lbase = s[getNext(s, i, 1, j-1)];
+  char rbase = s[getPrev(s, j, 1, i+1)];
+  return P->mismatchH[bp][lbase][rbase];
 }
 
 /*
@@ -573,14 +767,7 @@ int il22_energy(const char *s, rsize i, rsize k, rsize l, rsize j) {
    currently (11.09.2011) MAXLOOP is 30
    Input is just the size, i.e. number of bases, of the unpaired loop region: l
 */
-int il_ent(rsize l) {
-  assert(l > 1);
-  if (l > MAXLOOP) {
-      return P->internal_loop[MAXLOOP] + jacobson_stockmayer(l);
-  } else {
-      return P->internal_loop[l];
-  }
-}
+
 
 /*
    returns the stabilizing energy for the outermost bases of the unpaired regions stacking on the closing and the embedded basepair of the internal loop
@@ -615,22 +802,6 @@ int il_stack(const char *s, rsize i, rsize k, rsize l, rsize j) {
   char in_rbase = s[getPrev(s, k, 1, i+1)];
   return P->mismatchI[out_closingBP][out_lbase][out_rbase] +
          P->mismatchI[in_closingBP][in_lbase][in_rbase];
-}
-
-/*
-   returns the destabilizing penalty for internal loops with asymmetric sized unpaired loop regions
-   version 1999: currently (12.09.2011) ninio37[2] is 50 and MAX_NINIO is 300
-   version 2004: currently (12.09.2011) ninio37 is 60 and MAX_NINIO is 300
-   Input is
-     sl = size of the 5' unpaired loop region
-     sr = size of the 3' unpaired loop region
-*/
-int il_asym(rsize sl, rsize sr) {
-  int r = abs(sl-sr) * P->ninio[2];
-  if (r < MAX_NINIO) {
-    return r;
-  }
-  return MAX_NINIO;
 }
 
 /*
@@ -717,22 +888,6 @@ int il_energy(const char *s, rsize i, rsize k, rsize l, rsize j) {
   }
 
   return il_ent(sl+sr) + il_stack(s, i, k, l, j) + il_asym(sl, sr);
-}
-
-/*
-   returns destabilizing energy values for an unpaired loop smaller then MAXLOOP bases in a bulge loop
-   for larger loops jacobson_stockmayer is used.
-   currently (12.09.2011) MAXLOOP is 30
-   Input is
-     just the size, i.e. number of bases, of the unpaired loop region: l
-*/
-int bl_ent(rsize l) {
-  assert(l > 0);
-  if (l > MAXLOOP) {
-    return P->bulge[MAXLOOP] + jacobson_stockmayer(l);
-  } else {
-    return P->bulge[l];
-  }
 }
 
 /*
@@ -823,41 +978,6 @@ int br_energy(const char *s, rsize i, rsize k, rsize l, rsize j, rsize Xleft) {
 
   fprintf(stderr, "br_energy size < 1\n");
   assert(0);
-}
-
-/*
-   returns the stabilizing energy of two successive basepairs forming a stack
-       X          (X = some closed structure)
-     |   |
-   i+1 - j-1      (i+1 and j-1 form the embedded basepair)
-     |   |
-     i - j        (i and j form the closing basepair)
-     |   |
-     5'  3'
-   Input is
-     s = the input RNA sequence in bit encoding, i.e. N=0, A=1, C=2, G=3, U=4, GAP=5 (see /usr/include/librna/rnalib.h base_t)
-     i = the index (first base of s is 0, second 1, ...) of the 5' partner of the closing basepair
-     j = the index (first base of s is 0, second 1, ...) of the 3' partner of the closing basepair
-   stack37 data-arrangement:
-     1. index = closingBP = code for closing basepair i-j
-     2. index = enclosedBP = code for enclosed basepair i+1 and j-1. Note, basepair is reversed to preserver 5'-3' order
-*/
-int sr_energy(const char *s, rsize i, rsize j) {
-  int closingBP = bp_index(s[i], s[j]);
-  // Note, basepair is reversed to preserver 5'-3' order
-  int enclosedBP = bp_index(s[j-1], s[i+1]);
-  return P->stack[closingBP][enclosedBP];
-}
-
-/*
-   the same as "sr_energy" but here the input is not relative to the RNA input sequence, but can be any combination of four bases
-   currently used for the coaxial stacking of both stems of a pseudoknot
-*/
-int sr_pk_energy(char a, char b, char c, char d) {
-  int closingBP = bp_index(a, b);
-  // Note, basepair is reversed to preserver 5'-3' order
-  int enclosedBP = bp_index(d, c);
-  return P->stack[closingBP][enclosedBP];
 }
 
 /*
@@ -1030,115 +1150,464 @@ int ml_mismatch_energy(const char *s, rsize i, rsize j) {
   }
 }
 
-/*
-   returns the energy for initiating a multiloop
-   version 1999: currently (12.09.2011) this value is set to 340
-   version 2004: currently (12.09.2011) this value is set to 930
-*/
-int ml_energy(void) {
-  return P->MLclosing;
+#else
+
+#include <stdbool.h>
+
+static rsize getNext(const char *s, rsize pos, rsize steps,
+                     rsize rightBorder, unsigned currRow, unsigned maxRows) {
+  assert(steps > 0);
+  rsize nongaps = 0;
+  rsize x = pos+1;
+  if (x >= rightBorder)
+    return rightBorder;
+
+  static bool init = false;
+  static rsize *lookup;
+  static unsigned seqLen;
+  static unsigned triu;
+
+  if (!init) {
+    seqLen = strlen(s);
+    triu = (seqLen * (seqLen + 1)) / 2 + 1;
+    lookup = (rsize*) malloc(maxRows * triu * 3 * sizeof(rsize));
+  }
+
+  unsigned long index = triu * steps * currRow + pos * seqLen +
+                        rightBorder - ((pos * (pos + 1)) / 2);
+  if (lookup[index])
+    return lookup[index];
+
+  do {
+    if (s[x] != GAP_BASE)
+      ++nongaps;
+    if (s[x] == SEPARATOR_BASE)
+      return x-1;
+  } while (nongaps < steps && ++x < rightBorder);
+  
+  lookup[index] = x;
+
+  return x;
 }
 
-/*
-   returns the energy for initiating a stem within a multiloop
-   version 1999: currently (12.09.2011) this value is set to 40
-   version 2004: currently (12.09.2011) this value is set to -90
-*/
-int ul_energy(void) {
-  return P->MLintern[0];
+static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
+                     unsigned currRow, unsigned maxRows) {
+  assert(pos >= 0);
+  assert(steps > 0);
+  rsize x = pos-1;
+
+  if ((pos <= leftBorder) || (x <= leftBorder))
+    return leftBorder;
+  
+  rsize nongaps = 0;
+  
+  static bool init = false;
+  static rsize *lookup;
+  static unsigned seqLen;
+  static unsigned triu;
+
+  if (!init) {
+    seqLen = strlen(s);
+    triu = (seqLen * (seqLen + 1)) / 2 + 1;
+    lookup = (rsize*) malloc(maxRows * triu * 3 * sizeof(rsize));
+  }
+
+  unsigned long index = triu * steps * currRow + leftBorder * seqLen +
+                        pos - ((leftBorder * (leftBorder + 1)) / 2);
+  if (lookup[index])
+    return lookup[index];
+
+  do {
+    if (s[x] != GAP_BASE)
+      ++nongaps;
+    if (s[x] == SEPARATOR_BASE)
+      return x+1;
+  } while (nongaps < steps && --x > leftBorder);
+
+  lookup[index] = x;
+
+  return x;
 }
 
-/*
-   returns the energy for one unpaired base, not included into loops (hairpin-, bulge-, internal- loops), but in single stranded stretches next to closed substructures also in multiloops
-   currently (12.09.2011) this value is set to 0
-*/
-int sbase_energy(void) {
-  return 0;
+static int hl_stack(const char *s, rsize i, rsize j,
+                    unsigned currRow, unsigned maxRows) {
+  int bp = bp_index(s[i], s[j]);
+  char lbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
+  char rbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
+  return P->mismatchH[bp][lbase][rbase];
 }
 
-/*
-   same es sbase_energy, but for zero to n bases
-   currently (12.09.2011) this value is set to 0
-*/
-int ss_energy(rsize i, rsize j) {
-  return 0;
+int hl_energy(const char *s, rsize i, rsize j,
+              unsigned currRow, unsigned maxRows) {
+  assert(j-i > 1);
+
+  // if we are in an alignment, it might be true, that 5' partner of closing
+  // basepair is a gap from the start up to this position --> end gap
+  char lbase = s[getPrev(s, i+1, 1, 0, currRow, maxRows)];
+  if ((lbase == GAP_BASE) || (lbase == SEPARATOR_BASE)) {
+    return 0;
+  }
+
+  rsize size = j-i-1 - noGaps(s, i+1, j-1);
+
+  // destabilizing energy for the unpaired region in correlation to its length
+  int entropy = hl_ent(size);
+
+  // stabilizing energy for stacking bases
+  int stack_mismatch = hl_stack(s, i, j, currRow, maxRows);
+
+  // handling for hairpin loops in alignments, where the sequence is
+  // completely missing
+  if (size < 3) {
+    return 600;
+  }
+
+  // test for special loop cases, i.e. Tri-, Tetra- and Hexa-loops. Wired
+  // comparison stems from the Vienna Package: H/loop_energies.h method
+  // "E_Hairpin()"
+  if (size == 3 || size == 4 || size == 6) {
+    // loop type depends on ungapped loop sequence
+    char ungapped[j-i+1];
+    int sizeUngapped = ungapRegion(s, i, j, ungapped);
+        char loop[sizeUngapped+1];
+        loop[sizeUngapped] = 0;
+    decode(loop, ungapped, sizeUngapped);
+    if (sizeUngapped == 3+2) {
+      // special triloop cases
+      char tl[6] = {0, 0, 0, 0, 0, 0}, *ts;
+      strncpy(tl, loop, 5);
+      if ((ts=strstr(P->Triloops, tl))) {
+        return (P->Triloop_E[(ts - P->Triloops)/6]);
+      }
+    } else if (sizeUngapped == 4+2) {
+      // special tetraloop cases
+      char tl[7]={0}, *ts;
+      strncpy(tl, loop, 6);
+      if ((ts=strstr(P->Tetraloops, tl))) {
+        return (P->Tetraloop_E[(ts - P->Tetraloops)/7]);
+      }
+    } else if (sizeUngapped == 6+2) {
+      // special hexaloop cases
+      char tl[9]={0}, *ts;
+      strncpy(tl, loop, 8);
+      if ((ts=strstr(P->Hexaloops, tl))) {
+        return (P->Hexaloop_E[(ts - P->Hexaloops)/9]);
+      }
+    }
+  }
+
+  if (size == 3) {
+    // normal hairpins of loop size 3
+    return entropy + termau_energy(s, i, j);
+  } else {
+    // normal hairpins of loop sizes larger than three
+    return entropy + stack_mismatch;
+  }
+
+  // throw a warning to Bellman's GAP user, if they forget to restrict the
+  // loop region to sizes larger than two
+  fprintf(stderr, "hairpin loop < 3 found. Please use production\n");
+  fprintf(stderr, "hl(BASE, REGION with minsize(3), BASE)\n");
+  fprintf(stderr, "in your grammar.\n");
+  assert(0);
+  abort();
 }
 
-
-/*
-   scales the energy value x into a partition function value
-*/
-double mk_pf(double x) {
-  // temperature is defined in ViennaRNA/params/basic.h
-  return exp((-1.0 * x/100.0) / (GASCONST/1000 * (temperature + K0)));
+int il_stack(const char *s, rsize i, rsize k, rsize l, rsize j,
+             unsigned currRow, unsigned maxRows) {
+  int out_closingBP = bp_index(s[i], s[j]);
+  char out_lbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
+  char out_rbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
+  // Note, basepair and stacking bases are reversed to preserver 5'-3' order
+  int in_closingBP = bp_index(s[l], s[k]);
+  char in_lbase = s[getNext(s, l, 1, j-1, currRow, maxRows)];
+  char in_rbase = s[getPrev(s, k, 1, i+1, currRow, maxRows)];
+  return P->mismatchI[out_closingBP][out_lbase][out_rbase] +
+         P->mismatchI[in_closingBP][in_lbase][in_rbase];
 }
 
-/*
-   returns a partition function bonus for x unpaired bases
-*/
-double scale(int x) {
-  /* mean energy for random sequences: 184.3*length cal */
-  double mean_nrg = -0.1843;
-  double mean_scale = exp(-1.0 * mean_nrg / (GASCONST/1000 * (
-    temperature + K0)));
-
-  return (1.0 / pow(mean_scale, x));
+int il11_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows) {
+  int closingBP = bp_index(s[i], s[j]);
+  // we know that the enclosed base pair is at exactly this position, since
+  // both unpaired regions have size 1.  Note, basepair is reversed to
+  // preserver 5'-3' order.
+  int enclosedBP = bp_index(s[getPrev(s, j, 2, l, currRow, maxRows)],
+                            s[getNext(s, i, 2, k, currRow, maxRows)]);
+  char lbase = s[getNext(s, i, 1, k, currRow, maxRows)];
+  char rbase = s[getPrev(s, j, 1, l, currRow, maxRows)];
+  return P->int11[closingBP][enclosedBP][lbase][rbase];
 }
 
-/*
-   support function for dl_energy, for the case when the energy contribution must be independent of the input RNA sequence. This is the case where MacroStates has to use a n-tupel as answer type, where n reflects several possible dangling cases.
-       X          (X = some closed structure)
-     |   |
-     i - j        (i and j form the closing basepair)
-dangle   |        (dangle = 5' dangling base)
-     5'  3'
-   Input is
-     dangle = the code for the dangling base, note: here it is not an index of the input RNA sequence!
-     i = the code for the 5' partner of the closing basepair, note: here it is not an index of the input RNA sequence!
-     j = the code for the 3' partner of the closing basepair, note: here it is not an index of the input RNA sequence!
-*/
-int dl_dangle_dg(enum base_t dangle, enum base_t i, enum base_t j) {
-  int closingBP = bp_index(i, j);
-  int dd = P->dangle5[closingBP][dangle];
+int il12_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows) {
+  int closingBP = bp_index(s[i], s[j]);
+  // Note, basepair is reversed to preserver 5'-3' order
+  int enclosedBP = bp_index(s[getPrev(s, j, 3, l, currRow, maxRows)],
+                            s[getNext(s, i, 2, k, currRow, maxRows)]);
+  char lbase = s[getNext(s, i, 1, k, currRow, maxRows)];
+  char rbase = s[getPrev(s, j, 2, l, currRow, maxRows)];
+  char rrbase = s[getPrev(s, j, 1, l, currRow, maxRows)];
+  return P->int21[closingBP][enclosedBP][lbase][rbase][rrbase];
+}
+
+int il21_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+               unsigned currRow, unsigned maxRows) {
+  // Note, basepair is reversed to preserver 5'-3' order
+  int closingBP = bp_index(s[getPrev(s, j, 2, l, currRow, maxRows)],
+                           s[getNext(s, i, 3, k, currRow, maxRows)]);
+  int enclosedBP = bp_index(s[i], s[j]);
+  char lbase = s[getPrev(s, j, 1, l, currRow, maxRows)];
+  char rbase = s[getNext(s, i, 1, k, currRow, maxRows)];
+  char rrbase = s[getNext(s, i, 2, k, currRow, maxRows)];
+  return P->int21[closingBP][enclosedBP][lbase][rbase][rrbase];
+}
+
+int il22_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows) {
+  int closingBP = bp_index(s[i], s[j]);
+  // Note, basepair is reversed to preserver 5'-3' order
+  int enclosedBP = bp_index(s[getPrev(s, j, 3, l, currRow, maxRows)],
+                            s[getNext(s, i, 3, k, currRow, maxRows)]);
+  char lbase = s[getNext(s, i, 1, k, currRow, maxRows)];
+  char llbase = s[getNext(s, i, 2, k, currRow, maxRows)];
+  char rbase = s[getPrev(s, j, 2, l, currRow, maxRows)];
+  char rrbase = s[getPrev(s, j, 1, l, currRow, maxRows)];
+  return P->int22[closingBP][enclosedBP][lbase][llbase][rbase][rrbase];
+}
+
+int il_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+              unsigned currRow, unsigned maxRows) {
+  rsize sl = k-i-1 - noGaps(s, i+1, k-1);
+  rsize sr = j-l-1 - noGaps(s, l+1, j-1);
+
+  int out_closingBP = bp_index(s[i], s[j]);
+  int out_lbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
+  int out_rbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
+  // Note, basepair and stacking bases are reversed to preserver 5'-3' order
+  int in_closingBP = bp_index(s[l], s[k]);
+  int in_lbase = s[getNext(s, l, 1, j-1, currRow, maxRows)];
+  int in_rbase = s[getPrev(s, k, 1, i+1, currRow, maxRows)];
+
+  // internal loop really is an right bulge, because left unpaired region is
+  // just a gap
+  if (sl == 0) return br_energy(s, i, l+1, j-1, j, k, currRow, maxRows);
+  // internal loop really is an left bulge, because right unpaired region is
+  // just a gap
+  if (sr == 0) return bl_energy(s, i, i+1, k-1, j, l, currRow, maxRows);
+
+
+  if (sl == 1) {
+    if (sr == 1) {
+      return il11_energy(s, i, k, l, j, currRow, maxRows);
+    } else if (sr == 2) {
+      return il12_energy(s, i, k, l, j, currRow, maxRows);
+    } else {
+      return il_ent(sl+sr) + il_asym(sl, sr) +
+        P->mismatch1nI[out_closingBP][out_lbase][out_rbase] +
+        P->mismatch1nI[in_closingBP][in_lbase][in_rbase];
+    }
+  } else if (sl == 2) {
+    if (sr == 1) {
+      return il21_energy(s, i, k, l, j, currRow, maxRows);
+    } else if (sr == 2) {
+      return il22_energy(s, i, k, l, j, currRow, maxRows);
+    } else if (sr == 3) {
+      return P->internal_loop[5]+P->ninio[2] +
+        P->mismatch23I[out_closingBP][out_lbase][out_rbase] +
+        P->mismatch23I[in_closingBP][in_lbase][in_rbase];
+    }
+  } else if ((sl == 3) && (sr == 2)) {
+    return P->internal_loop[5]+P->ninio[2] +
+      P->mismatch23I[out_closingBP][out_lbase][out_rbase] +
+      P->mismatch23I[in_closingBP][in_lbase][in_rbase];
+  } else {
+    if (sr == 1) {
+      return il_ent(sl+sr) + il_asym(sl, sr) +
+        P->mismatch1nI[out_closingBP][out_lbase][out_rbase] +
+        P->mismatch1nI[in_closingBP][in_lbase][in_rbase];
+    }
+  }
+
+  return il_ent(sl+sr) + il_stack(s, i, k, l, j, currRow, maxRows) + il_asym(sl, sr);
+}
+
+int bl_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+              rsize Xright, unsigned currRow, unsigned maxRows) {
+  // this is of no biological relevance, just to avoid an underflow
+  assert(j >= 2);
+
+  rsize size = l-k+1 - noGaps(s, k, l);
+
+  if (size == 0) {
+    int closingBP = bp_index(s[i], s[j]);
+    // Note, basepair is reversed to preserver 5'-3' order
+    int enclosedBP = bp_index(s[getPrev(s, j, 1, Xright, currRow, maxRows)], s[l+1]);
+    return P->stack[closingBP][enclosedBP];
+  }
+  if (size == 1) {
+    int closingBP = bp_index(s[i], s[j]);
+    // Note, basepair is reversed to preserver 5'-3' order
+    int enclosedBP = bp_index(s[getPrev(s, j, 1, Xright, currRow, maxRows)], s[l+1]);
+    return bl_ent(size) + P->stack[closingBP][enclosedBP];
+  }
+  if (size > 1) {
+    return bl_ent(size) + termau_energy(s, i, j) +
+      termau_energy(s, getPrev(s, j, 1, Xright, currRow, maxRows), l+1);
+  }
+
+  fprintf(stderr, "bl_energy size < 1\n");
+  assert(0);
+}
+
+int br_energy(const char *s, rsize i, rsize k, rsize l, rsize j, rsize Xleft,
+              unsigned currRow, unsigned maxRows) {
+  // this is of no biological relevance, just to avoid an underflow
+  assert(j >= 1);
+
+  rsize size = l-k+1 - noGaps(s, k, l);
+
+  if (size == 0) {
+    int closingBP = bp_index(s[i], s[j]);
+    // Note, basepair is reversed to preserver 5'-3' order
+    int enclosedBP = bp_index(s[k-1], s[getNext(s, i, 1, Xleft, currRow, maxRows)]);
+    return P->stack[closingBP][enclosedBP];
+  }
+  if (size == 1) {
+    int closingBP = bp_index(s[i], s[j]);
+    // Note, basepair is reversed to preserver 5'-3' order
+    int enclosedBP = bp_index(s[k-1], s[getNext(s, i, 1, Xleft, currRow, maxRows)]);
+    return bl_ent(size) + P->stack[closingBP][enclosedBP];
+  }
+  if (size > 1) {
+    return bl_ent(size) + termau_energy(s, i, j) +
+      termau_energy(s, k-1, getNext(s, i, 1, Xleft, currRow, maxRows));
+  }
+
+  fprintf(stderr, "br_energy size < 1\n");
+  assert(0);
+}
+
+int dl_energy(const char *s, rsize i, rsize j,
+              unsigned currRow, unsigned maxRows) {
+  if (i == 0) return 0;
+  int closingBP = bp_index(s[i], s[j]);
+  char dbase = s[getPrev(s, i, 1, 0, currRow, maxRows)];
+  // RNAfold treats a gap like a N-base that is dangling on the pair.
+  // Strange but true.
+  if (dbase == GAP_BASE) dbase = N_BASE;
+  int dd = P->dangle5[closingBP][dbase];
   return (dd > 0) ? 0 : dd;  /* must be <= 0 */
 }
 
-/*
-   symmetric case to dl_dangle_dg
-       X          (X = some closed structure)
-     |   |
-     i - j        (i and j form the closing basepair)
-     |    dangle  (dangle = 3' dangling base)
-     5'  3'
-*/
-int dr_dangle_dg(enum base_t i, enum base_t j, enum base_t dangle) {
-  int closingBP = bp_index(i, j);
-  return P->dangle3[closingBP][dangle];
-  int dd = P->dangle3[closingBP][dangle];
+int dr_energy(const char *s, rsize i, rsize j, rsize n,
+              unsigned currRow, unsigned maxRows) {
+  if ((j+1) >= n) return 0;
+  int closingBP = bp_index(s[i], s[j]);
+  char dbase = s[getNext(s, j, 1, n-1, currRow, maxRows)];
+  // RNAfold treats a gap like a N-base that is dangling on the pair.
+  // Strange but true.
+  if (dbase == GAP_BASE) dbase = N_BASE;
+  int dd = P->dangle3[closingBP][dbase];
   return (dd > 0) ? 0 : dd;  /* must be <= 0 */
 }
 
-// added by gsauthof, 2012
-
-static const bool map_base_iupac[5][13] = {
-  /*      {N   , A    , C    , G    , U    , _    , +    , B    , D    ,
-           H    , R    , V    , Y    }, */
-  /* N */ {true, true , true , true , true , true , false, true , true ,
-           true , true , true , true },
-  /* A */ {true, true , false, false, false, false, false, false, true ,
-           true , true , true , false},
-  /* C */ {true, false, true , false, false, false, false, true , false,
-           true , false, true , true },
-  /* G */ {true, false, false, true , false, false, false, true , true ,
-           false, true , true , false},
-  /* U */ {true, false, false, false, true , false, false, true , true ,
-           true , false, false, true },
-};
-
-bool iupac_match(char base, char iupac_base) {
-  assert(base >= 0);
-  assert(base < 6);
-  assert(iupac_base >= 0);
-  assert(iupac_base < 13);
-  return map_base_iupac[base][iupac_base];
+int dli_energy(const char *s, rsize i, rsize j,
+               unsigned currRow, unsigned maxRows) {
+  // Note, basepair is reversed to preserver 5'-3' order
+  int closingBP = bp_index(s[j], s[i]);
+  char dbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
+  int dd = P->dangle3[closingBP][dbase];
+  return (dd > 0) ? 0 : dd;  /* must be <= 0 */
 }
+
+int dri_energy(const char *s, rsize i, rsize j,
+               unsigned currRow, unsigned maxRows) {
+  // Note, basepair is reversed to preserver 5'-3' order
+  int closingBP = bp_index(s[j], s[i]);
+  char dbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
+  int dd = P->dangle5[closingBP][dbase];
+  return (dd > 0) ? 0 : dd;  /* must be <= 0 */
+}
+
+int ext_mismatch_energy(const char *s, rsize i, rsize j, rsize n,
+                        unsigned currRow, unsigned maxRows) {
+  int rbasePos = getNext(s, j, 1, n-1, currRow, maxRows);
+  // we try to dangle left and right neighboring base if available. They are
+  // not if we already are at first or last base ...
+  if ((i > 0) && ((j+1) < n) &&
+      (s[i-1] != SEPARATOR_BASE) && ((j+1) <= rbasePos)) {
+    // or in outside mode, if left / right neighbor is the separator base
+    int closingBP = bp_index(s[i], s[j]);
+    int lbase = s[getPrev(s, i, 1, 0, currRow, maxRows)];
+    int rbase = s[rbasePos];
+    if (lbase == GAP_BASE) lbase = N_BASE;
+    if (rbase == GAP_BASE) rbase = N_BASE;
+    if ((lbase <  5) && (rbase <  5)) {
+      // left and right dangling positions are real bases
+      return P->mismatchExt[closingBP][lbase][rbase];
+    }
+    if ((lbase <  5) && (rbase >= 5)) {
+      // if right position is a gap and left position is a real base, we resort
+      // to a left dangle
+      return dl_energy(s, i, j, currRow, maxRows);
+    }
+    if ((lbase >= 5) && (rbase <  5)) {
+      // if left position is a gap and right position is a real base, we resort
+      // to a right dangle
+      return dr_energy(s, i, j, n, currRow, maxRows);
+    }
+    if ((lbase >= 5) && (rbase >= 5)) {
+      // if left and right positions are gaps, we just return 0;
+      return 0;
+    }
+  } else {
+    if ((i > 0) && (s[i-1] != SEPARATOR_BASE)) {
+      return dl_energy(s, i, j, currRow, maxRows);
+    }
+    if (((j+1) < n) && ((j+1) <= rbasePos)) {
+      return dr_energy(s, i, j, n, currRow, maxRows);
+    }
+    return 0;
+  }
+}
+
+int ml_mismatch_energy(const char *s, rsize i, rsize j,
+                       unsigned currRow, unsigned maxRows) {
+  // Note, basepairs and stacking bases are reversed to preserver 5'-3' order
+  int closingBP = bp_index(s[j], s[i]);
+  int lbase = s[getPrev(s, j, 1, i+1, currRow, maxRows)];
+  int rbase = s[getNext(s, i, 1, j-1, currRow, maxRows)];
+  if ((lbase <  5) && (rbase <  5)) {
+    // left and right dangling positions are real bases
+    return P->mismatchM[closingBP][lbase][rbase];
+  }
+  if ((lbase <  5) && (rbase >= 5)) {
+    // if right position is a gap and left position is a real base, we resort
+    // to a left dangle
+    return dli_energy(s, i, j, currRow, maxRows);
+  }
+  if ((lbase >= 5) && (rbase <  5)) {
+    // if left position is a gap and right position is a real base, we resort
+    // to a right dangle
+    return dri_energy(s, i, j, currRow, maxRows);
+  }
+  if ((lbase >= 5) && (rbase >= 5)) {
+    // if left and right positions are gaps, we just return 0;
+    return 0;
+  }
+}
+
+/* like hl_energy, just no penalty for size > 4 structures */
+int hl_energy_stem(const char *s, rsize i, rsize j,
+                   unsigned currRow, unsigned maxRows) {
+  int r = hl_energy(s, i, j, currRow, maxRows);
+  rsize size = j-i-1 - noGaps(s, i+1, j-1);
+  if (size >= 4) {
+    int stack_mismatch = hl_stack(s, i, j, currRow, maxRows);
+    return r - stack_mismatch;
+  }
+  return r;
+}
+
+#endif

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1170,13 +1170,17 @@ static rsize getNext(const char *s, rsize pos, rsize steps,
   if (!init) {
     seqLen = strlen(s);
     triu = (seqLen * (seqLen + 1)) / 2 + 1;
-    lookup = (rsize*) malloc(maxRows * triu * 3 * sizeof(rsize));
+    unsigned long size = maxRows * triu * 3;
+    lookup = calloc(size, sizeof(rsize));
+    init = true;
   }
 
   unsigned long index = triu * steps * currRow + pos * seqLen +
                         rightBorder - ((pos * (pos + 1)) / 2);
-  if (lookup[index])
+  
+  if (lookup[index]) {
     return lookup[index];
+  }
 
   do {
     if (s[x] != GAP_BASE)
@@ -1209,13 +1213,17 @@ static rsize getPrev(const char *s, rsize pos, rsize steps, rsize leftBorder,
   if (!init) {
     seqLen = strlen(s);
     triu = (seqLen * (seqLen + 1)) / 2 + 1;
-    lookup = (rsize*) malloc(maxRows * triu * 3 * sizeof(rsize));
+    unsigned long size = maxRows * triu * 3;
+    lookup = calloc(size, sizeof(rsize));
+    init = true;
   }
 
   unsigned long index = triu * steps * currRow + leftBorder * seqLen +
                         pos - ((leftBorder * (leftBorder + 1)) / 2);
-  if (lookup[index])
+
+  if (lookup[index]) {
     return lookup[index];
+  }
 
   do {
     if (s[x] != GAP_BASE)

--- a/librna/rnalib.h
+++ b/librna/rnalib.h
@@ -116,6 +116,8 @@ int il21_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
                 unsigned currRow, unsigned maxRows);
 int il22_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
                 unsigned currRow, unsigned maxRows);
+int il_stack(const char *s, rsize i, rsize k, rsize l, rsize j,
+             unsigned currRow, unsigned maxRows);
 int hl_energy(const char *s, rsize i, rsize j,
               unsigned currRow, unsigned maxRows);
 int hl_energy_stem(const char *s, rsize i, rsize j,
@@ -138,6 +140,7 @@ int ext_mismatch_energy(const char *s, rsize i, rsize j, rsize n,
                         unsigned currRow, unsigned maxRows);
 int ml_mismatch_energy(const char *s, rsize i, rsize j,
                        unsigned currRow, unsigned maxRows);
+
 #endif
 
 #endif  // LIBRNA_RNALIB_H_

--- a/librna/rnalib.h
+++ b/librna/rnalib.h
@@ -86,7 +86,7 @@ int bl_ent(rsize l);
 int il_asym(rsize sl, rsize sr);
 int il_ent(rsize l);
 
-#ifndef LOOKUP
+#ifndef GAP_LOOKUP
 int hl_energy(const char *s, rsize i, rsize j);
 int hl_energy_stem(const char *s, rsize i, rsize j);
 int il_energy(const char *s, rsize i, rsize j, rsize k, rsize l);

--- a/librna/rnalib.h
+++ b/librna/rnalib.h
@@ -23,7 +23,7 @@
 #ifndef LIBRNA_RNALIB_H_
 #define LIBRNA_RNALIB_H_
 
-//#define GAP_LOOKUP
+// #define GAP_LOOKUP
 
 // Sun CC (C++ compiler) really makes an effort to educate the user that parts
 // of C99 are not standarized in the last C++ specification

--- a/librna/rnalib.h
+++ b/librna/rnalib.h
@@ -23,7 +23,7 @@
 #ifndef LIBRNA_RNALIB_H_
 #define LIBRNA_RNALIB_H_
 
-#define LOOKUP
+//#define GAP_LOOKUP
 
 // Sun CC (C++ compiler) really makes an effort to educate the user that parts
 // of C99 are not standarized in the last C++ specification

--- a/librna/rnalib.h
+++ b/librna/rnalib.h
@@ -20,9 +20,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 }}} */
-
 #ifndef LIBRNA_RNALIB_H_
 #define LIBRNA_RNALIB_H_
+
+#define LOOKUP
 
 // Sun CC (C++ compiler) really makes an effort to educate the user that parts
 // of C99 are not standarized in the last C++ specification
@@ -55,20 +56,10 @@ bool test_macrostate_mme_assumption();
 
 int termau_energy(const char *s, rsize i, rsize j);
 int duplex_energy(void);
-int hl_energy(const char *s, rsize i, rsize j);
-int hl_energy_stem(const char *s, rsize i, rsize j);
-int il_energy(const char *s, rsize i, rsize j, rsize k, rsize l);
-int bl_energy(const char *s, rsize bl, rsize i, rsize j, rsize br,
-              rsize Xright);
-int br_energy(const char *s, rsize bl, rsize i, rsize j, rsize br, rsize Xleft);
+
 int sr_energy(const char *s, rsize i, rsize j);
 int sr_pk_energy(char a, char b, char c, char d);
-int dl_energy(const char *s, rsize i, rsize j);
-int dr_energy(const char *s, rsize i, rsize j, rsize n);
-int dli_energy(const char *s, rsize i, rsize j);
-int dri_energy(const char *s, rsize i, rsize j);
-int ext_mismatch_energy(const char *s, rsize i, rsize j, rsize n);
-int ml_mismatch_energy(const char *s, rsize i, rsize j);
+
 int ml_energy(void);
 int ul_energy(void);
 int sbase_energy(void);
@@ -91,12 +82,62 @@ int bp_index(char x, char y);
 /* the below 8 functions are exposed to recreate energy computation of the
    original RNAhybrid, i.e. Haskell and ADPc */
 int bl_ent(rsize l);
+
+int il_asym(rsize sl, rsize sr);
+int il_ent(rsize l);
+
+#ifndef LOOKUP
+int hl_energy(const char *s, rsize i, rsize j);
+int hl_energy_stem(const char *s, rsize i, rsize j);
+int il_energy(const char *s, rsize i, rsize j, rsize k, rsize l);
+int bl_energy(const char *s, rsize bl, rsize i, rsize j, rsize br,
+              rsize Xright);
+int br_energy(const char *s, rsize bl, rsize i, rsize j, rsize br, rsize Xleft);
+int dl_energy(const char *s, rsize i, rsize j);
+int dr_energy(const char *s, rsize i, rsize j, rsize n);
+int dli_energy(const char *s, rsize i, rsize j);
+int dri_energy(const char *s, rsize i, rsize j);
+int ext_mismatch_energy(const char *s, rsize i, rsize j, rsize n);
+int ml_mismatch_energy(const char *s, rsize i, rsize j);
+
 int il11_energy(const char *s, rsize i, rsize k, rsize l, rsize j);
 int il12_energy(const char *s, rsize i, rsize k, rsize l, rsize j);
 int il21_energy(const char *s, rsize i, rsize k, rsize l, rsize j);
 int il22_energy(const char *s, rsize i, rsize k, rsize l, rsize j);
-int il_ent(rsize l);
 int il_stack(const char *s, rsize i, rsize k, rsize l, rsize j);
-int il_asym(rsize sl, rsize sr);
+
+
+#else
+int il11_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows);
+int il12_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows);
+int il21_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows);
+int il22_energy(const char *s, rsize i, rsize k, rsize l, rsize j,
+                unsigned currRow, unsigned maxRows);
+int hl_energy(const char *s, rsize i, rsize j,
+              unsigned currRow, unsigned maxRows);
+int hl_energy_stem(const char *s, rsize i, rsize j,
+                   unsigned currRow, unsigned maxRows);
+int il_energy(const char *s, rsize i, rsize j, rsize k, rsize l,
+              unsigned currRow, unsigned maxRows);
+int bl_energy(const char *s, rsize bl, rsize i, rsize j, rsize br,
+              rsize Xright, unsigned currRow, unsigned maxRows);
+int br_energy(const char *s, rsize bl, rsize i, rsize j, rsize br, rsize Xleft,
+              unsigned currRow, unsigned maxRows);
+int dl_energy(const char *s, rsize i, rsize j,
+              unsigned currRow, unsigned maxRows);
+int dr_energy(const char *s, rsize i, rsize j, rsize n,
+              unsigned currRow, unsigned maxRows);
+int dli_energy(const char *s, rsize i, rsize j,
+               unsigned currRow, unsigned maxRows);
+int dri_energy(const char *s, rsize i, rsize j,
+               unsigned currRow, unsigned maxRows);
+int ext_mismatch_energy(const char *s, rsize i, rsize j, rsize n,
+                        unsigned currRow, unsigned maxRows);
+int ml_mismatch_energy(const char *s, rsize i, rsize j,
+                       unsigned currRow, unsigned maxRows);
+#endif
 
 #endif  // LIBRNA_RNALIB_H_

--- a/rtlib/rna.hh
+++ b/rtlib/rna.hh
@@ -456,7 +456,7 @@ inline int hl_energy(const Basic_Subsequence<alphabet, pos_type> &a) {
   #else
   static std::unordered_map<std::string, int> lookup;
   #endif
-  
+
   static char tmp[13];
   snprintf(tmp, sizeof(tmp), "%d%d", a.i, a.j);
   std::string key(tmp);

--- a/rtlib/rna.hh
+++ b/rtlib/rna.hh
@@ -764,7 +764,8 @@ inline int il_energy(const Basic_Subsequence<alphabet, pos_type> &a,
   assert(a.seq->rows() == b.seq->rows());
 
   for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += il_energy(a.seq->row(k), a.i-1, a.j, b.i-1, b.j, k, a.seq->rows());
+    energy += il_energy(a.seq->row(k), a.i-1, a.j, b.i-1, b.j,
+                        k, a.seq->rows());
 
   return energy;
 }
@@ -790,7 +791,8 @@ inline int bl_energy(const Basic_Subsequence<alphabet, pos_type> &lr,
   assert(lr.seq->rows() == rb.seq->rows());
 
   for (unsigned k = 0; k < lr.seq->rows(); k++)
-    energy += bl_energy(lr.seq->row(k), lr.i-1, lr.i, lr.j-1, rb.j-1, rb.j-2, k, lr.seq->rows());
+    energy += bl_energy(lr.seq->row(k), lr.i-1, lr.i, lr.j-1, rb.j-1, rb.j-2,
+                        k, lr.seq->rows());
 
   return energy;
 }
@@ -816,7 +818,8 @@ inline int br_energy(const Basic_Subsequence<alphabet, pos_type> &lb,
   assert(lb.seq->rows() == rr.seq->rows());
 
   for (unsigned k = 0; k < lb.seq->rows(); k++)
-    energy += br_energy(lb.seq->row(k), lb.i, rr.i, rr.j-1, rr.j, lb.i+1, k, lb.seq->rows());
+    energy += br_energy(lb.seq->row(k), lb.i, rr.i, rr.j-1, rr.j, lb.i+1,
+                        k, lb.seq->rows());
 
   return energy;
 }
@@ -931,7 +934,8 @@ inline int ext_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
   assert(a.seq->rows() == b.seq->rows());
 
   for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += ext_mismatch_energy(a.seq->row(k), a.i, b.j-1, a.seq->n, k, a.seq->rows());
+    energy += ext_mismatch_energy(a.seq->row(k), a.i, b.j-1, a.seq->n,
+                                  k, a.seq->rows());
 
   return energy;
 }

--- a/rtlib/rna.hh
+++ b/rtlib/rna.hh
@@ -25,6 +25,7 @@
 #ifndef RTLIB_RNA_HH_
 #define RTLIB_RNA_HH_
 
+
 extern "C" {
 #include <rnalib.h>
 }
@@ -219,119 +220,6 @@ inline int termau_energy(const Basic_Subsequence<alphabet, pos_type> &a,
 }
 
 /*
-   returns the energy value for a basepair closing an unpaired hairpin loop
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the unpaired
-        loop region of the hairpin
-   The positions of the bases of the closing basepair are assumed to be directly
-   left of the 5'-start of the unpaired loop region and directly right to the
-   3'-end of the unpaired loop region
-*/
-template<typename alphabet, typename pos_type>
-inline int hl_energy(const Basic_Subsequence<alphabet, pos_type> &a) {
-  int energy = 0;
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += hl_energy(a.seq->row(k), a.i-1, a.j);
-
-  return energy;
-}
-
-/*
-   similar to hl_energy, but without the stabilizing contribution of stacking
-   the outmost bases onto the closing basepairs for hairpins with unpaired loops
-   larger than 4
-*/
-template<typename alphabet, typename pos_type>
-inline int hl_energy_stem(const Basic_Subsequence<alphabet, pos_type> &a) {
-  int energy = 0;
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += hl_energy_stem(a.seq->row(k), a.i-1, a.j);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a basepair closing an internal loop with some
-   bases bulged at 5' and 3' side and an arbitrary closed substructure
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5'
-        unpaired loop region of the internal loop
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 3'
-        unpaired loop region of the internal loop
-   The positions of the bases of the closing basepair are assumed to be
-   directly left of the 5'-start of the 5' unpaired loop region and directly
-   right to the 3'-end of the 3' unpaired loop region
-   The positions of the bases of the embedded basepair are assumed to be
-   directly right of the 5'-end of the 5' unpaired loop region and directly
-   left to the 5'-start of the 3' unpaired loop region
-*/
-template<typename alphabet, typename pos_type>
-inline int il_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += il_energy(a.seq->row(k), a.i-1, a.j, b.i-1, b.j);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a basepair closing an left bulge loop with some
-   bases bulged at 5' side and an arbitrary closed substructure
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5'
-        unpaired loop region of the left bulge
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 3' base
-        of the closing basepair
-   The 5' position of the base of the closing basepair is assumed to be directly
-   left of the 5'-start of the unpaired loop region
-   The positions of the bases of the embedded basepair are assumed to be
-   directly right of the 3'-end of the unpaired loop region and directly left
-   to the 3' base of the closing basepair
-*/
-template<typename alphabet, typename pos_type>
-inline int bl_energy(const Basic_Subsequence<alphabet, pos_type> &lr,
-    const Basic_Subsequence<alphabet, pos_type> &rb) {
-  int energy = 0;
-  assert(lr.seq->rows() == rb.seq->rows());
-
-  for (unsigned k = 0; k < lr.seq->rows(); k++)
-    energy += bl_energy(lr.seq->row(k), lr.i-1, lr.i, lr.j-1, rb.j-1, rb.j-2);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a basepair closing an right bulge loop with some
-   bases bulged at 3' side and an arbitrary closed substructure
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5' base
-        of the closing basepair
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 6'
-        unpaired loop region of the right bulge
-   The 3' position of the base of the closing basepair is assumed to be
-   directly right of the 3'-end of the unpaired loop region
-   The positions of the bases of the embedded basepair are assumed to be
-   directly right of the 5' partner of the closing basepair and directly left
-   to the 5'-start of the unpaired loop region
-*/
-template<typename alphabet, typename pos_type>
-inline int br_energy(const Basic_Subsequence<alphabet, pos_type> &lb,
-    const Basic_Subsequence<alphabet, pos_type> &rr) {
-  int energy = 0;
-  assert(lb.seq->rows() == rr.seq->rows());
-
-  for (unsigned k = 0; k < lb.seq->rows(); k++)
-    energy += br_energy(lb.seq->row(k), lb.i, rr.i, rr.j-1, rr.j, lb.i+1);
-
-  return energy;
-}
-
-/*
    returns the energy value for two successive basepairs which form a stack
    Input is
      a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5' base
@@ -363,144 +251,6 @@ inline int sr_energy(const Basic_Subsequence<alphabet, pos_type> &a,
 template<typename alphabet, typename pos_type>
 inline int sr_pk_energy(char a, char b, char c, char d) {
   return sr_pk_energy(a, b, c, d);
-}
-
-/*
-   returns the energy value for a base directly left of a stem, which dangles
-   onto this stem from outside
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
-        5' base of stem
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
-        3' base of stem
-   The position of the dangling base is assumed to be directly left of the
-   outermost 5' partner of the stems basepair
-*/
-template<typename alphabet, typename pos_type>
-inline int dl_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += dl_energy(a.seq->row(k), a.i, b.j-1);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a base directly right of a stem, which dangles
-   onto this stem from outside
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
-        5' base of stem
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
-        3' base of stem
-   The position of the dangling base is assumed to be directly right to the
-   outermost 3' partner of the stems basepair
-*/
-template<typename alphabet, typename pos_type>
-inline int dr_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += dr_energy(a.seq->row(k), a.i, b.j-1, a.seq->n);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a base directly 3' of a stem, which dangles onto
-   this stem from inside
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
-        5' base of stem
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
-        3' base of stem
-   The position of the dangling base is assumed to be directly right of the 3'
-   partner of the innermost basepair of the stem
-*/
-template<typename alphabet, typename pos_type>
-inline int dli_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += dli_energy(a.seq->row(k), a.i, b.j-1);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a base directly 5' of a stem, which dangles onto
-   this stem from inside
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
-        5' base of stem
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
-        3' base of stem
-   The position of the dangling base is assumed to be directly left of the 5'
-   partner of the innermost basepair of the stem
-*/
-template<typename alphabet, typename pos_type>
-inline int dri_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += dri_energy(a.seq->row(k), a.i, b.j-1);
-
-  return energy;
-}
-
-/*
-   returns the energy value for two bases directly surrounding a stem, which
-   dangles onto this stem from outside
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
-        5' base of stem
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
-        3' base of stem
-   The positions of the dangling bases are assumed to be directly left of the 5'
-   partner and right of the 3' partner of the outermost basepair of the stem
-*/
-template<typename alphabet, typename pos_type>
-inline int ext_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += ext_mismatch_energy(a.seq->row(k), a.i, b.j-1, a.seq->n);
-
-  return energy;
-}
-
-/*
-   returns the energy value for a base directly 3' of a stem and a second base
-   directly 5' of the same stem, which both dangle onto this stem from inside
-   Input is
-     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
-        5' base of stem
-     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
-        3' base of stem
-   The positions of the dangling bases are assumed to be directly right of the
-   5' partner and left of the 3' partner of the innermost basepair of the stem
-*/
-template<typename alphabet, typename pos_type>
-inline int ml_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
-    const Basic_Subsequence<alphabet, pos_type> &b) {
-  int energy = 0;
-  assert(a.seq->rows() == b.seq->rows());
-
-  for (unsigned k = 0; k < a.seq->rows(); k++)
-    energy += ml_mismatch_energy(a.seq->row(k), a.i, b.j-1);
-
-  return energy;
 }
 
 /*
@@ -703,5 +453,512 @@ class iupac_filter {
     }
 };
 
+#ifndef LOOKUP
+
+/*
+   returns the energy value for a basepair closing an unpaired hairpin loop
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the unpaired
+        loop region of the hairpin
+   The positions of the bases of the closing basepair are assumed to be directly
+   left of the 5'-start of the unpaired loop region and directly right to the
+   3'-end of the unpaired loop region
+*/
+template<typename alphabet, typename pos_type>
+inline int hl_energy(const Basic_Subsequence<alphabet, pos_type> &a) {
+  int energy = 0;
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += hl_energy(a.seq->row(k), a.i-1, a.j);
+
+  return energy;
+}
+
+/*
+   similar to hl_energy, but without the stabilizing contribution of stacking
+   the outmost bases onto the closing basepairs for hairpins with unpaired loops
+   larger than 4
+*/
+template<typename alphabet, typename pos_type>
+inline int hl_energy_stem(const Basic_Subsequence<alphabet, pos_type> &a) {
+  int energy = 0;
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += hl_energy_stem(a.seq->row(k), a.i-1, a.j);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a basepair closing an internal loop with some
+   bases bulged at 5' and 3' side and an arbitrary closed substructure
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5'
+        unpaired loop region of the internal loop
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 3'
+        unpaired loop region of the internal loop
+   The positions of the bases of the closing basepair are assumed to be
+   directly left of the 5'-start of the 5' unpaired loop region and directly
+   right to the 3'-end of the 3' unpaired loop region
+   The positions of the bases of the embedded basepair are assumed to be
+   directly right of the 5'-end of the 5' unpaired loop region and directly
+   left to the 5'-start of the 3' unpaired loop region
+*/
+template<typename alphabet, typename pos_type>
+inline int il_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += il_energy(a.seq->row(k), a.i-1, a.j, b.i-1, b.j);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a basepair closing an left bulge loop with some
+   bases bulged at 5' side and an arbitrary closed substructure
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5'
+        unpaired loop region of the left bulge
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 3' base
+        of the closing basepair
+   The 5' position of the base of the closing basepair is assumed to be directly
+   left of the 5'-start of the unpaired loop region
+   The positions of the bases of the embedded basepair are assumed to be
+   directly right of the 3'-end of the unpaired loop region and directly left
+   to the 3' base of the closing basepair
+*/
+template<typename alphabet, typename pos_type>
+inline int bl_energy(const Basic_Subsequence<alphabet, pos_type> &lr,
+    const Basic_Subsequence<alphabet, pos_type> &rb) {
+  int energy = 0;
+  assert(lr.seq->rows() == rb.seq->rows());
+
+  for (unsigned k = 0; k < lr.seq->rows(); k++)
+    energy += bl_energy(lr.seq->row(k), lr.i-1, lr.i, lr.j-1, rb.j-1, rb.j-2);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a basepair closing an right bulge loop with some
+   bases bulged at 3' side and an arbitrary closed substructure
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5' base
+        of the closing basepair
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 6'
+        unpaired loop region of the right bulge
+   The 3' position of the base of the closing basepair is assumed to be
+   directly right of the 3'-end of the unpaired loop region
+   The positions of the bases of the embedded basepair are assumed to be
+   directly right of the 5' partner of the closing basepair and directly left
+   to the 5'-start of the unpaired loop region
+*/
+template<typename alphabet, typename pos_type>
+inline int br_energy(const Basic_Subsequence<alphabet, pos_type> &lb,
+    const Basic_Subsequence<alphabet, pos_type> &rr) {
+  int energy = 0;
+  assert(lb.seq->rows() == rr.seq->rows());
+
+  for (unsigned k = 0; k < lb.seq->rows(); k++)
+    energy += br_energy(lb.seq->row(k), lb.i, rr.i, rr.j-1, rr.j, lb.i+1);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly left of a stem, which dangles
+   onto this stem from outside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly left of the
+   outermost 5' partner of the stems basepair
+*/
+template<typename alphabet, typename pos_type>
+inline int dl_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dl_energy(a.seq->row(k), a.i, b.j-1);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly right of a stem, which dangles
+   onto this stem from outside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly right to the
+   outermost 3' partner of the stems basepair
+*/
+template<typename alphabet, typename pos_type>
+inline int dr_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dr_energy(a.seq->row(k), a.i, b.j-1, a.seq->n);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly 3' of a stem, which dangles onto
+   this stem from inside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly right of the 3'
+   partner of the innermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int dli_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dli_energy(a.seq->row(k), a.i, b.j-1);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly 5' of a stem, which dangles onto
+   this stem from inside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly left of the 5'
+   partner of the innermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int dri_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dri_energy(a.seq->row(k), a.i, b.j-1);
+
+  return energy;
+}
+
+/*
+   returns the energy value for two bases directly surrounding a stem, which
+   dangles onto this stem from outside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        3' base of stem
+   The positions of the dangling bases are assumed to be directly left of the 5'
+   partner and right of the 3' partner of the outermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int ext_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += ext_mismatch_energy(a.seq->row(k), a.i, b.j-1, a.seq->n);
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly 3' of a stem and a second base
+   directly 5' of the same stem, which both dangle onto this stem from inside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        3' base of stem
+   The positions of the dangling bases are assumed to be directly right of the
+   5' partner and left of the 3' partner of the innermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int ml_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += ml_mismatch_energy(a.seq->row(k), a.i, b.j-1);
+
+  return energy;
+}
+
+#else
+
+/*
+   returns the energy value for a basepair closing an unpaired hairpin loop
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the unpaired
+        loop region of the hairpin
+   The positions of the bases of the closing basepair are assumed to be directly
+   left of the 5'-start of the unpaired loop region and directly right to the
+   3'-end of the unpaired loop region
+*/
+template<typename alphabet, typename pos_type>
+inline int hl_energy(const Basic_Subsequence<alphabet, pos_type> &a) {
+  int energy = 0;
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += hl_energy(a.seq->row(k), a.i-1, a.j, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   similar to hl_energy, but without the stabilizing contribution of stacking
+   the outmost bases onto the closing basepairs for hairpins with unpaired loops
+   larger than 4
+*/
+template<typename alphabet, typename pos_type>
+inline int hl_energy_stem(const Basic_Subsequence<alphabet, pos_type> &a) {
+  int energy = 0;
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += hl_energy_stem(a.seq->row(k), a.i-1, a.j, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a basepair closing an internal loop with some
+   bases bulged at 5' and 3' side and an arbitrary closed substructure
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5'
+        unpaired loop region of the internal loop
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 3'
+        unpaired loop region of the internal loop
+   The positions of the bases of the closing basepair are assumed to be
+   directly left of the 5'-start of the 5' unpaired loop region and directly
+   right to the 3'-end of the 3' unpaired loop region
+   The positions of the bases of the embedded basepair are assumed to be
+   directly right of the 5'-end of the 5' unpaired loop region and directly
+   left to the 5'-start of the 3' unpaired loop region
+*/
+template<typename alphabet, typename pos_type>
+inline int il_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += il_energy(a.seq->row(k), a.i-1, a.j, b.i-1, b.j, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a basepair closing an left bulge loop with some
+   bases bulged at 5' side and an arbitrary closed substructure
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5'
+        unpaired loop region of the left bulge
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 3' base
+        of the closing basepair
+   The 5' position of the base of the closing basepair is assumed to be directly
+   left of the 5'-start of the unpaired loop region
+   The positions of the bases of the embedded basepair are assumed to be
+   directly right of the 3'-end of the unpaired loop region and directly left
+   to the 3' base of the closing basepair
+*/
+template<typename alphabet, typename pos_type>
+inline int bl_energy(const Basic_Subsequence<alphabet, pos_type> &lr,
+    const Basic_Subsequence<alphabet, pos_type> &rb) {
+  int energy = 0;
+  assert(lr.seq->rows() == rb.seq->rows());
+
+  for (unsigned k = 0; k < lr.seq->rows(); k++)
+    energy += bl_energy(lr.seq->row(k), lr.i-1, lr.i, lr.j-1, rb.j-1, rb.j-2, k, lr.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a basepair closing an right bulge loop with some
+   bases bulged at 3' side and an arbitrary closed substructure
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 5' base
+        of the closing basepair
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the 6'
+        unpaired loop region of the right bulge
+   The 3' position of the base of the closing basepair is assumed to be
+   directly right of the 3'-end of the unpaired loop region
+   The positions of the bases of the embedded basepair are assumed to be
+   directly right of the 5' partner of the closing basepair and directly left
+   to the 5'-start of the unpaired loop region
+*/
+template<typename alphabet, typename pos_type>
+inline int br_energy(const Basic_Subsequence<alphabet, pos_type> &lb,
+    const Basic_Subsequence<alphabet, pos_type> &rr) {
+  int energy = 0;
+  assert(lb.seq->rows() == rr.seq->rows());
+
+  for (unsigned k = 0; k < lb.seq->rows(); k++)
+    energy += br_energy(lb.seq->row(k), lb.i, rr.i, rr.j-1, rr.j, lb.i+1, k, lb.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly left of a stem, which dangles
+   onto this stem from outside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly left of the
+   outermost 5' partner of the stems basepair
+*/
+template<typename alphabet, typename pos_type>
+inline int dl_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dl_energy(a.seq->row(k), a.i, b.j-1, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly right of a stem, which dangles
+   onto this stem from outside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly right to the
+   outermost 3' partner of the stems basepair
+*/
+template<typename alphabet, typename pos_type>
+inline int dr_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dr_energy(a.seq->row(k), a.i, b.j-1, a.seq->n, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly 3' of a stem, which dangles onto
+   this stem from inside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly right of the 3'
+   partner of the innermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int dli_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dli_energy(a.seq->row(k), a.i, b.j-1, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly 5' of a stem, which dangles onto
+   this stem from inside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        3' base of stem
+   The position of the dangling base is assumed to be directly left of the 5'
+   partner of the innermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int dri_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += dri_energy(a.seq->row(k), a.i, b.j-1, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for two bases directly surrounding a stem, which
+   dangles onto this stem from outside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the outermost
+        3' base of stem
+   The positions of the dangling bases are assumed to be directly left of the 5'
+   partner and right of the 3' partner of the outermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int ext_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += ext_mismatch_energy(a.seq->row(k), a.i, b.j-1, a.seq->n, k, a.seq->rows());
+
+  return energy;
+}
+
+/*
+   returns the energy value for a base directly 3' of a stem and a second base
+   directly 5' of the same stem, which both dangle onto this stem from inside
+   Input is
+     a) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        5' base of stem
+     b) a Bellman's GAP terminal (e.g. BASE or REGION) describing the innermost
+        3' base of stem
+   The positions of the dangling bases are assumed to be directly right of the
+   5' partner and left of the 3' partner of the innermost basepair of the stem
+*/
+template<typename alphabet, typename pos_type>
+inline int ml_mismatch_energy(const Basic_Subsequence<alphabet, pos_type> &a,
+    const Basic_Subsequence<alphabet, pos_type> &b) {
+  int energy = 0;
+  assert(a.seq->rows() == b.seq->rows());
+
+  for (unsigned k = 0; k < a.seq->rows(); k++)
+    energy += ml_mismatch_energy(a.seq->row(k), a.i, b.j-1, k, a.seq->rows());
+
+  return energy;
+}
+
+#endif
 
 #endif  // RTLIB_RNA_HH_

--- a/rtlib/rna.hh
+++ b/rtlib/rna.hh
@@ -285,8 +285,9 @@ inline int il_energy(const Basic_Subsequence<alphabet, pos_type> &a,
   #else
   static std::unordered_map<std::string, int> lookup;
   #endif
-  char tmp[5];
-  int size = snprintf(tmp, sizeof(tmp), "%d%d%d%d", a.i, a.j, b.i, b.j);
+
+  static char tmp[25];
+  snprintf(tmp, sizeof(tmp), "%d%d%d%d", a.i, a.j, b.i, b.j);
   std::string key(tmp);
 
   #endif
@@ -344,8 +345,9 @@ inline int bl_energy(const Basic_Subsequence<alphabet, pos_type> &lr,
   #else
   static std::unordered_map<std::string, int> lookup;
   #endif
-  char tmp[5];
-  int size = snprintf(tmp, sizeof(tmp), "%d%d%d%d", lr.i, lr.j, rb.i, rb.j);
+
+  static char tmp[25];
+  snprintf(tmp, sizeof(tmp), "%d%d%d%d", lr.i, lr.j, rb.i, rb.j);
   std::string key(tmp);
 
   #endif
@@ -403,8 +405,9 @@ inline int br_energy(const Basic_Subsequence<alphabet, pos_type> &lb,
   #else
   static std::unordered_map<std::string, int> lookup;
   #endif
-  char tmp[5];
-  int size = snprintf(tmp, sizeof(tmp), "%d%d%d%d", lb.i, lb.j, rr.i, rr.j);
+
+  static char tmp[25];
+  snprintf(tmp, sizeof(tmp), "%d%d%d%d", lb.i, lb.j, rr.i, rr.j);
   std::string key(tmp);
 
   #endif
@@ -453,8 +456,9 @@ inline int hl_energy(const Basic_Subsequence<alphabet, pos_type> &a) {
   #else
   static std::unordered_map<std::string, int> lookup;
   #endif
-  char tmp[3];
-  int size = snprintf(tmp, sizeof(tmp), "%d%d", a.i, a.j);
+  
+  static char tmp[13];
+  snprintf(tmp, sizeof(tmp), "%d%d", a.i, a.j);
   std::string key(tmp);
 
   #endif


### PR DESCRIPTION
The `getNext` and `getPrev` functions, which are implemented in the [rnalib.c](https://github.com/jlab/gapc/blob/master/librna/rnalib.c) source file and are used to calculate the index/sequence position of the next non-gap base in a given range/region of the input sequence/alignment, are usually called a lot during the runtime of Gapc compilations. Most of those calls are with identical function parameters. Hoping that we might be able to save some execution time in the Gapc compilations, I tried to reuse the calculation results of these functions by storing them in a lookup array and thus to avoid multiple recalculations of the same results. Unfortunately, it seems as if the index calculation required to retrieve the correct lookup value takes about as long as the calculations the functions actually carry out, which negates any potential performance gain and actually slightly increases the total execution time of the program I tested (blue line in plot below).

Example call used during benchmark (to increase alignment size, I concatenated each alignment row to itself a few times): 
`./out GAGGGUGCCUCUGACCGUGCCCG_____AUGAC___ACCAACCUGCCCAAUGAAGCACGGGCGACCGUGGGGA___GGGUGUU_______________________________________CCCUGUGGGAACCCUCGCCAUUCACGGCGAGGAGGAGGUCAGCUCCUCCACGUUC#GAGGGCUG_UCUGACCCAGCCCG_____AUGAG___CUGAACCUGCCCUGUGACCUACCGGCGACGGUAGGGAGAAGGGUGUU_______________________________________CCCCGUGGGAACCUCCGAGCUUUAGCUCGGAGAGGAGGUCAGCUUUUAACAUUUC#GAGGGCUG_UCUGACCCAGCCCG_____AUGAG___CUGAACCUGCCCUGUGACCUACCGGCGACGGUAGGGAGAAGGGUGUU_______________________________________CCCCGUGGGAACCUCCGAGCUUUAGCUCGGAGAGGAGGUCAGCUUUUAACAUUUC#GUGGUCUUUAC_GCCCAAGGGAGGGGUAAUGGGCCUGAGACCGGGCCC_UCGGGC______CGAAC___CGAAACC_GGUG__ACGGGAGUAGGUGGAUGAGAGCCCGCAAACCUCUCCCCGCCC_GUUGAAAGCCUCGCCCUUCAAGGCGGGGAGGAGGUCAGGAGG_AGAUAACC#GAGGGUAGCUCUGACUCUGCCCG_____AUGAC___ACCAACCUGCCCUGUGACCUAUCGGCGACGAUAAGUAGCAGGGUGUU_______________________________________CCGUGUUGGAACCUCCACCCUUUAGGU_GGAGAGAAGAUCAG___UUAAAAUUCC#`

![mfe_benchmark_time](https://user-images.githubusercontent.com/87138636/199267519-f7bdeed0-ecc2-4c49-844a-0a9ab6f9acb5.png)

Interestingly, the overall impact of the `getNext` and `getPrev` functions on the total execution time doesn't seem to be big at all, at least when using the example alignment that I used (see example call). As you can see in the plot above, the execution time of the program when modifying `getNext` and `getPrev` by writing the statement `return 1;` as the first line in both functions (red line), which essentially makes them as fast as they could possibly be (and obviously wrong; but this is only an example), barely improves the execution time over the currently used implementation (green line).

To summarize: Even though it made sense to assume that there is/was optimization potential in regards to reusing `getNext` and `getPrev` calculation results, the actual calculations carried out in these functions seem to require too little time to make the additional overhead of lookup index calculation etc. worthwhile, which is actually a good thing though, because that means that the functions are already about as fast as they could possibly be.
