### PR TITLE
precalculate the first 10000 scale values

### DIFF
--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -55,6 +55,8 @@
 #include "ViennaRNA/params/io.h"
 #include "ViennaRNA/fold_vars.h"
 
+#define LOOKUP_SIZE 10000
+
 static vrna_param_t  *P = 0;
 
 
@@ -1076,28 +1078,28 @@ double mk_pf(double x) {
 
 double getScaleValue(int x) {
   static bool init = false;
-  static const double mean_nrg = -0.1843;
-  static double lookup[10000];
+  static const double MEAN_NRG = -0.1843;
+  static double lookup[LOOKUP_SIZE];
   static double mean_scale;
 
   if (!init) {
     // precalculate the first 10000 scale values
-    mean_scale = exp(-1.0 * mean_nrg /
+    mean_scale = exp(-1.0 * MEAN_NRG /
                      (GASCONST / 1000 *
                       (temperature + K0)));
 
-    for (int i = 0; i < 10000; i++) {
+    for (int i = 0; i < LOOKUP_SIZE; i++) {
       lookup[i] = 1.0 / pow(mean_scale, i);
     }
 
     init = true;
   }
 
-  if (x < 10000) {
+  if (x < LOOKUP_SIZE) {
     return lookup[x];
   } else {
     /* in the rare cases that the required scale value
-       is bigger than or equal to 10000, calculate the
+       is bigger than or equal to LOOKUP_SIZE, calculate the
        value on the spot */
     return 1.0 / pow(mean_scale, x);
   }


### PR DESCRIPTION
In order to reduce the execution time of some Gapc compilations, we figured it would make sense to precalculate (most of) the required return values of the `scale` function from the [rnalib.c](https://github.com/jlab/gapc/blob/master/librna/rnalib.c)-file, since this function is called quite often in the return statements of certain algebra functions. As expected, precalculating the scale values reduces the execution time of the Gapc compilation I tested (`gapc -p alg_pfunc nodangle.gap`) by a significant amount (see benchmark below).

![scale_benchmark](https://user-images.githubusercontent.com/87138636/199490393-007aa61c-7031-4c6d-ac75-b467849be8af.png)

I once again tested multiple scale value lookup implementations (dynamic lookup (blue line), full precalculation) and concluded that precalculating the scale values beforehand as well as moving this process to a dedicated function reduces the execution time the most (red line). It is a little bit suprising to see that moving the precalculation to a dedicated function improves the execution speed over doing this process directly in the `scale` function (green line) though. There probably must be some sort of compiler optimization happening there.
