### PR TITLE
precalculate mk_pf energy scaling values

### DIFF
--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1090,6 +1090,8 @@ static double get_mkpf_value(double x) {
     init = true;
   }
 
+  return exp((-1.0 * x / 100.0) / divisor);
+
   int index = x + HALF;
 
   if (index >= 0 && index < LOOKUP_SIZE) {

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1090,11 +1090,9 @@ static double get_mkpf_value(double x) {
     init = true;
   }
 
-  return exp((-1.0 * x / 100.0) / divisor);
-
   int index = x + HALF;
 
-  if (index >= 0 && index < LOOKUP_SIZE) {
+  if (index >= 0 && index < LOOKUP_SIZE && trunc(x) == x) {
     return lookup[index];
   } else {
     /* if the input energy value isn't within the range

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1067,7 +1067,7 @@ int ss_energy(rsize i, rsize j) {
   return 0;
 }
 
-static double get_mkpf_value(double x) {
+static double get_mkpf_value(double energy) {
   /* -precalculate LOOKUP_SIZE mk_pf partition function values
      -since input values can be negative,
       values within the range -HALF <= x < HALF
@@ -1077,39 +1077,41 @@ static double get_mkpf_value(double x) {
   static const int HALF = LOOKUP_SIZE / 2;
   static double lookup[LOOKUP_SIZE];
   static double divisor;
+  static int index;
 
   if (!init) {
-    // temperature is defined in ViennaRNA/params/basic.h
+    /* temperature is defined in ViennaRNA/params/basic.h
+       and can be adjusted with the -T flag at runtime */
     divisor = GASCONST / 1000 * (temperature + K0);
 
     // calculate mk_pf partition function values in range -HALF <= x < HALF
-    for (int i = 0; i < LOOKUP_SIZE; i++) {
-      lookup[i] = exp((-1.0 * (i - HALF) / 100.0) / divisor);
+    for (int i = -HALF; i < HALF; i++) {
+      lookup[i + HALF] = exp((-1.0 * i / 100.0) / divisor);
     }
 
     init = true;
   }
 
-  int index = x + HALF;
+  index = energy + HALF;
 
-  if (index >= 0 && index < LOOKUP_SIZE && trunc(x) == x) {
+  if (index >= 0 && index < LOOKUP_SIZE && trunc(energy) == energy) {
     return lookup[index];
   } else {
     /* if the input energy value isn't within the range
        -HALF <= x < HALF (meaning the index isn't within the range
        0 <= i < LOOKUP_SIZE), calculate the mk_pf value on the spot */
-    return exp((-1.0 * x / 100.0) / divisor);
+    return exp((-1.0 * energy / 100.0) / divisor);
   }
 }
 
 /*
    scales the energy value x into a partition function value
 */
-double mk_pf(double x) {
-  return get_mkpf_value(x);
+double mk_pf(double energy) {
+  return get_mkpf_value(energy);
 }
 
-static double get_scale_value(int x) {
+static double get_scale_value(int subword_size) {
   static bool init = false;
   static const double MEAN_NRG = -0.1843;
   static double lookup[LOOKUP_SIZE];
@@ -1117,6 +1119,8 @@ static double get_scale_value(int x) {
 
   if (!init) {
     // precalculate the first 10000 scale values
+
+    // temperature can be adjusted with the -T flag at runtime
     mean_scale = exp(-1.0 * MEAN_NRG /
                      (GASCONST / 1000 *
                       (temperature + K0)));
@@ -1128,22 +1132,22 @@ static double get_scale_value(int x) {
     init = true;
   }
 
-  if (x < LOOKUP_SIZE) {
-    return lookup[x];
+  if (subword_size < LOOKUP_SIZE) {
+    return lookup[subword_size];
   } else {
     /* in the rare cases that the required scale value
        is bigger than or equal to LOOKUP_SIZE, calculate the
        value on the spot */
-    return 1.0 / pow(mean_scale, x);
+    return 1.0 / pow(mean_scale, subword_size);
   }
 }
 
 /*
-   returns a partition function bonus for x unpaired bases
+   returns a partition function bonus for subword_size unpaired bases
 */
-double scale(int x) {
+double scale(int subword_size) {
   /* mean energy for random sequences: 184.3*length cal */
-  return get_scale_value(x);
+  return get_scale_value(subword_size);
 }
 
 /*

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1067,7 +1067,7 @@ int ss_energy(rsize i, rsize j) {
   return 0;
 }
 
-double get_mkpf_value(int x) {
+static double get_mkpf_value(double x) {
   /* -precalculate LOOKUP_SIZE mk_pf partition function values
      -since input values can be negative,
       values within the range -HALF <= x < HALF
@@ -1083,8 +1083,8 @@ double get_mkpf_value(int x) {
     divisor = GASCONST / 1000 * (temperature + K0);
 
     // calculate mk_pf partition function values in range -HALF <= x < HALF
-    for (int i = -HALF; i < HALF; i++) {
-      lookup[i + HALF] = exp((-1.0 * i / 100.0) / divisor);
+    for (int i = 0; i < LOOKUP_SIZE; i++) {
+      lookup[i] = exp((-1.0 * (i - HALF) / 100.0) / divisor);
     }
 
     init = true;
@@ -1092,7 +1092,7 @@ double get_mkpf_value(int x) {
 
   int index = x + HALF;
 
-  if (index > 0 && index < LOOKUP_SIZE) {
+  if (index >= 0 && index < LOOKUP_SIZE) {
     return lookup[index];
   } else {
     /* if the input energy value isn't within the range
@@ -1109,7 +1109,7 @@ double mk_pf(double x) {
   return get_mkpf_value(x);
 }
 
-double get_scale_value(int x) {
+static double get_scale_value(int x) {
   static bool init = false;
   static const double MEAN_NRG = -0.1843;
   static double lookup[LOOKUP_SIZE];

--- a/librna/rnalib.c
+++ b/librna/rnalib.c
@@ -1067,11 +1067,11 @@ int ss_energy(rsize i, rsize j) {
   return 0;
 }
 
-double getMkpfValue(int x) {
-  /* precalculate LOOKUP_SIZE mk_pf values;
-     since input values can be negative,
-     values within the range (-HALF, HALF)
-     will be calculated (HALF = LOOKUP_SIZE / 2) */
+double get_mkpf_value(int x) {
+  /* -precalculate LOOKUP_SIZE mk_pf partition function values
+     -since input values can be negative,
+      values within the range -HALF <= x < HALF
+      will be calculated (HALF = LOOKUP_SIZE / 2) */
 
   static bool init = false;
   static const int HALF = LOOKUP_SIZE / 2;
@@ -1082,11 +1082,11 @@ double getMkpfValue(int x) {
     // temperature is defined in ViennaRNA/params/basic.h
     divisor = GASCONST / 1000 * (temperature + K0);
 
-    // calculate mk_pf values from -HALF to HALF
+    // calculate mk_pf partition function values in range -HALF <= x < HALF
     for (int i = -HALF; i < HALF; i++) {
       lookup[i + HALF] = exp((-1.0 * i / 100.0) / divisor);
     }
-    
+
     init = true;
   }
 
@@ -1095,6 +1095,9 @@ double getMkpfValue(int x) {
   if (index > 0 && index < LOOKUP_SIZE) {
     return lookup[index];
   } else {
+    /* if the input energy value isn't within the range
+       -HALF <= x < HALF (meaning the index isn't within the range
+       0 <= i < LOOKUP_SIZE), calculate the mk_pf value on the spot */
     return exp((-1.0 * x / 100.0) / divisor);
   }
 }
@@ -1103,15 +1106,10 @@ double getMkpfValue(int x) {
    scales the energy value x into a partition function value
 */
 double mk_pf(double x) {
-  /* getMkpfValue takes an argument of type int instead of
-     type double, because the energy functions
-     (e.g. il_energy) actually return int instead of double;
-     so we let C do an implicit conversion here */
-
-  return getMkpfValue(x);
+  return get_mkpf_value(x);
 }
 
-double getScaleValue(int x) {
+double get_scale_value(int x) {
   static bool init = false;
   static const double MEAN_NRG = -0.1843;
   static double lookup[LOOKUP_SIZE];
@@ -1145,7 +1143,7 @@ double getScaleValue(int x) {
 */
 double scale(int x) {
   /* mean energy for random sequences: 184.3*length cal */
-  return getScaleValue(x);
+  return get_scale_value(x);
 }
 
 /*


### PR DESCRIPTION
Similarly to the last PR #154 , I figured it would also makes sense to precalculate a relatively large amount of the scaled energy values the `mk_pf` function from the [rnalib.c](https://github.com/jlab/gapc/blob/master/librna/rnalib.c)-file returns, since this function is also called quite often in the return statements of certain algebra functions.

![mkpf_benchmark](https://user-images.githubusercontent.com/87138636/200337864-3ca1ea93-4a2a-4f9e-93ee-2ec48c9d3dc9.png)

As you can see in the benchmark plot above, precalulating just the first 10000 `mk_pf` scaled energy values reduces the execution time of the Gapc compilation I tested (`gapc -p alg_pfunc nodangle.gap`) by about as much as is theoretically possible for this particular function (see green line for maximum possible speedup), while only minimally increasing the required memory (by such a small amount that you can't even see it in the memory usage plot below).

![mkpf_benchmark_space](https://user-images.githubusercontent.com/87138636/200337884-161ffdda-e18e-4d4b-83e4-259fa230d26d.png)