### PR TITLE
H sum

### DIFF
--- a/rtlib/traces.hh
+++ b/rtlib/traces.hh
@@ -107,14 +107,17 @@ class candidate {
     return value;
   }
 
-  std::vector<Trace> get_normalized_candidate(double eval) const {
+  /* we need to normalize the individual trace values into probabilities
+   * trace values can come in different flavors, depending on what the
+   * user uses as scoring schema. See Algebra::check_derivative
+   */
+  std::vector<Trace> get_normalized_candidate(
+    double eval, double (func)(double a, double b)) const {
     std::vector<Trace> res;
     for (std::vector<Trace>::const_iterator part = this->sub_components.begin();
          part != this->sub_components.end(); ++part) {
-//      res.push_back({std::get<0>(*part), std::get<1>(*part),
-//                     this->get_value() / eval});
       res.push_back({std::get<0>(*part), std::get<1>(*part),
-                     exp(this->get_value() - eval)});
+                    func(this->get_value() , eval)});
     }
     return res;
   }
@@ -129,11 +132,12 @@ typedef std::vector<candidate> NTtraces;
 inline
 std::vector<Trace> normalize_traces(std::vector<Trace> *tabulated,
                                     const std::vector<candidate> &candidates,
-                                    double eval) {
+                                    double eval,
+                                    double (func)(double a, double b)) {
   std::vector<std::tuple<std::string, std::vector<unsigned int>, double > > res;
   for (std::vector<candidate>::const_iterator i = candidates.begin();
        i != candidates.end(); ++i) {
-    std::vector<Trace> comp = (*i).get_normalized_candidate(eval);
+    std::vector<Trace> comp = (*i).get_normalized_candidate(eval, func);
     res.insert(res.end(), comp.begin(), comp.end());
   }
   return res;

--- a/rtlib/traces.hh
+++ b/rtlib/traces.hh
@@ -111,8 +111,10 @@ class candidate {
     std::vector<Trace> res;
     for (std::vector<Trace>::const_iterator part = this->sub_components.begin();
          part != this->sub_components.end(); ++part) {
+//      res.push_back({std::get<0>(*part), std::get<1>(*part),
+//                     this->get_value() / eval});
       res.push_back({std::get<0>(*part), std::get<1>(*part),
-                     this->get_value() / eval});
+                     exp(this->get_value() - eval)});
     }
     return res;
   }

--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -397,14 +397,17 @@ Algebra *Algebra::copy() const {
 // a special function that normalizes traces
 bool Algebra::check_derivative() {
   bool r = true;
-  hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.find(
-    FN_NAME_DERIVATIVE_NORMALIZER);
-  if (i == this->fns.end()) {
-    std::ostringstream o1;
-    o1 << *(*this->fns.begin()).second->return_type;
-    std::string ans_type = o1.str();
+  for (hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.begin();
+       i != this->fns.end(); ++i) {
+    if ((*i).second->is_Choice_Fn()) {
+      // skip choice functions, as their type is a list of something
+      continue;
+    } else {
+      std::ostringstream o1;
+      o1 << *i->second->return_type;
+      std::string ans_type = o1.str();
 
-    std::string msg =
+      std::string msg =
 "You requested the computation of derivatives. This requires the "
 "conversion of\n"
 "weights of alternative sub-solutions (q) into probabilities. Please"
@@ -422,7 +425,9 @@ FN_NAME_DERIVATIVE_NORMALIZER + "(" + ans_type + " q, " + ans_type + \
 "   log(prob.)    |    expsum    | exp(q - pfunc) \n"
 "   log(1/prob.)  |  negexpsum   | exp(pfunc - q) \n"
 "   exp(score)    |     sum      |   q / pfunc    \n";
-    Log::instance()->error(msg);
+      Log::instance()->error(msg);
+      break;
+    }
   }
   return r;
 }

--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -41,7 +41,7 @@
 #include "printer.hh"
 
 #include "mode.hh"
-
+#include "grammar.hh"
 
 
 
@@ -304,6 +304,12 @@ void Algebra::derive_role() {
           o << "Declared role of algebra choice function "
             << *fn->name << " (in algebra " << *name
             << ") does not match autodetected role " << tmp << '.';
+          /* do not raise the warning, if the choice function has been
+           * automatically generated for derivative outside application */
+          if ((*i).first.substr(0, sizeof(PREFIX_DERIVATIVE)-1).compare(
+              PREFIX_DERIVATIVE) == 0) {
+            continue;
+          }
           Log::instance()->warning(fn->location, o.str());
         }
     }

--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -392,3 +392,37 @@ Algebra *Algebra::copy() const {
   }
   return o;
 }
+
+// tests if Signature and Algebra for derivative computation contain
+// a special function that normalizes traces
+bool Algebra::check_derivative() {
+  bool r = true;
+  hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.find(
+    FN_NAME_DERIVATIVE_NORMALIZER);
+  if (i == this->fns.end()) {
+    std::ostringstream o1;
+    o1 << *(*this->fns.begin()).second->return_type;
+    std::string ans_type = o1.str();
+
+    std::string msg =
+"You requested the computation of derivatives. This requires the "
+"conversion of\n"
+"weights of alternative sub-solutions (q) into probabilities. Please"
+" provide\n"
+"an additional algebra function:\n\n    " + ans_type + " " + \
+FN_NAME_DERIVATIVE_NORMALIZER + "(" + ans_type + " q, " + ans_type + \
+" pfunc)\n\n"
+"to your algebra \"" + *this->name + "\". Depending on your scoring "
+"schema and\n"
+"choice function, the body of " + FN_NAME_DERIVATIVE_NORMALIZER + \
+" should normalize e.g.\n\n"
+"  scoring schema | choice func. | normalization  \n"
+"  -----------------------------------------------\n"
+"   prob.         |     sum      |   q / pfunc    \n"
+"   log(prob.)    |    expsum    | exp(q - pfunc) \n"
+"   log(1/prob.)  |  negexpsum   | exp(pfunc - q) \n"
+"   exp(score)    |     sum      |   q / pfunc    \n";
+    Log::instance()->error(msg);
+  }
+  return r;
+}

--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -407,24 +407,21 @@ bool Algebra::check_derivative() {
         std::ostringstream o1;
         o1 << *i->second->return_type;
         ans_type = o1.str();
+        break;
       }
   }
 
   hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.find(
       FN_NAME_DERIVATIVE_NORMALIZER);
   if (i == this->fns.end()) {
-    std::ostringstream o1;
-    o1 << *i->second->return_type;
-    std::string ans_type = o1.str();
-
     std::string msg =
 "You requested the computation of derivatives. This requires the "
 "conversion of\n"
 "weights of alternative sub-solutions (q) into probabilities. Please"
 " provide\n"
-"an additional algebra function:\n\n    " + ans_type + " " + \
+"an additional algebra function, e.g.:\n\n    " + ans_type + " " + \
 FN_NAME_DERIVATIVE_NORMALIZER + "(" + ans_type + " q, " + ans_type + \
-" pfunc)\n\n"
+" pfunc) {\n      return q <OPERATOR> pfunc;\n    }\n\n"
 "to your algebra \"" + *this->name + "\". Depending on your scoring "
 "schema and\n"
 "choice function, the body of " + FN_NAME_DERIVATIVE_NORMALIZER + \

--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -397,17 +397,27 @@ Algebra *Algebra::copy() const {
 // a special function that normalizes traces
 bool Algebra::check_derivative() {
   bool r = true;
-  for (hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.begin();
-       i != this->fns.end(); ++i) {
-    if ((*i).second->is_Choice_Fn()) {
-      // skip choice functions, as their type is a list of something
-      continue;
-    } else {
-      std::ostringstream o1;
-      o1 << *i->second->return_type;
-      std::string ans_type = o1.str();
 
-      std::string msg =
+  std::string ans_type = "unknown type";
+  for (hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.begin();
+         i != this->fns.end(); ++i) {
+      if ((*i).second->is_Choice_Fn()) {
+        continue;
+      } else {
+        std::ostringstream o1;
+        o1 << *i->second->return_type;
+        ans_type = o1.str();
+      }
+  }
+
+  hashtable<std::string, Fn_Def*>::const_iterator i = this->fns.find(
+      FN_NAME_DERIVATIVE_NORMALIZER);
+  if (i == this->fns.end()) {
+    std::ostringstream o1;
+    o1 << *i->second->return_type;
+    std::string ans_type = o1.str();
+
+    std::string msg =
 "You requested the computation of derivatives. This requires the "
 "conversion of\n"
 "weights of alternative sub-solutions (q) into probabilities. Please"
@@ -425,9 +435,7 @@ FN_NAME_DERIVATIVE_NORMALIZER + "(" + ans_type + " q, " + ans_type + \
 "   log(prob.)    |    expsum    | exp(q - pfunc) \n"
 "   log(1/prob.)  |  negexpsum   | exp(pfunc - q) \n"
 "   exp(score)    |     sum      |   q / pfunc    \n";
-      Log::instance()->error(msg);
-      break;
-    }
+    Log::instance()->error(msg);
   }
   return r;
 }

--- a/src/algebra.hh
+++ b/src/algebra.hh
@@ -49,6 +49,7 @@ class Fn_Def;
 class Signature;
 class Filter;
 
+const char FN_NAME_DERIVATIVE_NORMALIZER[] = "normalize_derivative";
 
 class Algebra : public Signature_Base {
  private:
@@ -109,6 +110,8 @@ class Algebra : public Signature_Base {
     std::pair<std::string*, Type::Base*> &p, const Loc &l);
 
   bool check_signature(Signature &s);
+
+  bool check_derivative();
 
   void set_fns(const hashtable<std::string, Fn_Def*> &h);
 

--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -637,7 +637,27 @@ void Printer::Cpp::print(const Fn_Def &fn_def) {
     }
     stream << ')' << endl;
   } else {
-    stream << indent() << *fn_def.return_type << ' ';
+    stream << indent();
+    if (fwd_decls &&
+      fn_def.name->compare(FN_NAME_DERIVATIVE_NORMALIZER) == 0) {
+      /* TODO(sjanssen): why is it necessary that the function is declared
+       * static at all? The aim is to pass the function as a pointer to
+       * functions in rtlib/trace.hh
+       * https://stackoverflow.com/questions/12662891/
+       *   how-can-i-pass-a-member-function-where-a-free-function-is-expected
+       * https://stackoverflow.com/questions/2374847/
+       *   passing-member-function-pointer-to-member-object-in-c
+       * https://stackoverflow.com/questions/30541367/
+       *   c-cannot-convert-double-to-double-for-argument-1-to-void
+       *   -sortdouble-in
+       * https://stackoverflow.com/questions/6339970/
+       *   c-using-function-as-parameter
+       * https://www.geeksforgeeks.org/
+       *   passing-a-function-as-a-parameter-in-cpp/
+       */
+      stream << "static ";
+    }
+    stream << *fn_def.return_type << ' ';
     if (!fwd_decls && !in_class) {
       stream << class_name << "::";
     }

--- a/src/fn_def.cc
+++ b/src/fn_def.cc
@@ -3288,3 +3288,24 @@ Fn_Def *Fn_Def::copy() const {
     o->paras.push_back((*i)->copy());
   return o;
 }
+
+Fn_Def *Fn_Def::copy_parameters(std::string *name) const {
+  Fn_Def *o = this->copy();
+
+  o->parameters.clear();
+  o->paras.clear();
+  o->types.clear();
+  o->names.clear();
+
+  std::list<Para_Decl::Base*> *o_paras = new std::list<Para_Decl::Base*>();
+  for (std::list<Para_Decl::Base*>::const_iterator i = this->paras.begin();
+       i != this->paras.end(); ++i) {
+    o_paras->push_back((*i)->copy(true));
+  }
+  o->set_paras(*o_paras);
+
+  o->name = name;
+
+  return o;
+}
+

--- a/src/fn_def.hh
+++ b/src/fn_def.hh
@@ -131,6 +131,7 @@ class Fn_Def : public Fn_Decl {
 
     explicit Fn_Def(const Fn_Decl &other);
 
+
     void set_paras(const std::list<Para_Decl::Base*> &l);
 
     void add_para(Type::Base *type, std::string *n);
@@ -314,6 +315,13 @@ class Fn_Def : public Fn_Decl {
     bool check_ntparas(const Fn_Decl &d);
 
     Fn_Def *copy() const;
+
+    /* this will construct a new Fn_Def object, while using this as template,
+     * but replaces the parameters with deep copies instead of using the same
+     * references (as Fn_Def::copy() would do).
+     * Furthermore, name of the new Fn_Def is takes as first argument.
+     */
+    Fn_Def *copy_parameters(std::string *name) const;
 };
 
 

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -392,7 +392,7 @@ class Main {
     if (opts.outside_nt_list.size() > 0) {
       grammar->inject_outside_nts(opts.outside_nt_list);
       if (opts.derivative > 0) {
-    	grammar->replace_choice_for_derivatives();
+        grammar->replace_choice_for_derivatives();
       }
     }
 

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -549,6 +549,11 @@ class Main {
         }
     }
 
+    if (opts.derivative > 0) {
+      // if user requests derivative computation, check that user also
+      // provided a normalization function for forward computation
+      instance->product->algebra()->check_derivative();
+    }
 
     driver.ast.set_float_accuracy(*instance, opts.float_acc);
     if (opts.pareto == 3) {

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -391,6 +391,9 @@ class Main {
     // inject rules for outside grammar
     if (opts.outside_nt_list.size() > 0) {
       grammar->inject_outside_nts(opts.outside_nt_list);
+      if (opts.derivative > 0) {
+    	grammar->replace_choice_for_derivatives();
+      }
     }
 
     // configure the window and k-best mode

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -1340,7 +1340,7 @@ void Grammar::inject_outside_nts(std::vector<std::string> outside_nt_list) {
 /* if outside grammar is generated to produce derivatives, the
  * DP values are probabilities and as such must be summed for
  * alternative production rules. If however the algebra uses e.g.
- * log()-space for numerical stabilitie, choice function of
+ * log()-space for numerical stability, choice function of
  * inside parts is expsum instead of sum. We here replace the
  * user provided choice function with "sum". */
 void Grammar::replace_choice_for_derivatives() {
@@ -1351,8 +1351,8 @@ void Grammar::replace_choice_for_derivatives() {
        i != ast.signature->choice_fns.end(); ++i) {
     Fn_Decl *in_choice_decl = (*i).second;
     Fn_Decl *out_choice_decl = new Fn_Decl(
-      new Type::Choice(new Type::List(in_choice_decl->return_type->component()),
-                       Loc()),
+      new Type::Choice(new Type::List(
+        in_choice_decl->return_type->component()), Loc()),
       new std::string(PREFIX_DERIVATIVE + (*i).first));
     for (std::list<Type::Base*>::const_iterator t = \
          in_choice_decl->types.begin();

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -54,6 +54,7 @@
 #include "symbol.hh"
 #include "signature.hh"
 #include "fn_def.hh"
+#include "para_decl.hh"
 
 
 void Grammar::add_nt(Symbol::NT *nt) {
@@ -1335,102 +1336,77 @@ void Grammar::inject_outside_nts(std::vector<std::string> outside_nt_list) {
     "Grammar has been modified into an outside version.");
 }
 
+
+/* if outside grammar is generated to produce derivatives, the
+ * DP values are probabilities and as such must be summed for
+ * alternative production rules. If however the algebra uses e.g.
+ * log()-space for numerical stabilitie, choice function of
+ * inside parts is expsum instead of sum. We here replace the
+ * user provided choice function with "sum". */
 void Grammar::replace_choice_for_derivatives() {
-  std::string PREFIX_DERIVATIVE = std::string("derivative_");
-  /* if outside grammar is generated to produce derivatives, the
-   * DP values are probabilities and as such must be summed for
-   * alternative production rules. If however the algebra uses e.g.
-   * log()-space for numerical stabilitie, choice function of
-   * inside parts is expsum instead of sum. We here replace the
-   * user provided choice function with "sum". */
-
-
   // for every user defined choice function (in inside grammar part):
   // create an independent copy for the outside parts and add to signature
-  for (hashtable<std::string, Fn_Decl*>::const_iterator i = ast.signature->choice_fns.begin(); i != ast.signature->choice_fns.end(); ++i) {
-	Fn_Decl *in_choice_decl = (*i).second;
-	Fn_Decl *out_choice_decl = new Fn_Decl(
-			new Type::Choice(new Type::List(in_choice_decl->return_type->component()), Loc()),
-			new std::string(PREFIX_DERIVATIVE + (*i).first));
-	for (std::list<Type::Base*>::const_iterator t = in_choice_decl->types.begin(); t != in_choice_decl->types.end(); ++t) {
-		out_choice_decl->types.push_back((*t)->clone());
-	}
-	ast.signature->choice_fns[*out_choice_decl->name] = out_choice_decl;
-	ast.signature->decls[*out_choice_decl->name] = out_choice_decl;
+  for (hashtable<std::string, Fn_Decl*>::const_iterator i = \
+       ast.signature->choice_fns.begin();
+       i != ast.signature->choice_fns.end(); ++i) {
+    Fn_Decl *in_choice_decl = (*i).second;
+    Fn_Decl *out_choice_decl = new Fn_Decl(
+      new Type::Choice(new Type::List(in_choice_decl->return_type->component()),
+                       Loc()),
+      new std::string(PREFIX_DERIVATIVE + (*i).first));
+    for (std::list<Type::Base*>::const_iterator t = \
+         in_choice_decl->types.begin();
+         t != in_choice_decl->types.end(); ++t) {
+      out_choice_decl->types.push_back((*t)->clone());
+    }
+    ast.signature->choice_fns[*out_choice_decl->name] = out_choice_decl;
+    ast.signature->decls[*out_choice_decl->name] = out_choice_decl;
 
-	// also adding function definition to every algebra
-	for (hashtable<std::string, Algebra*>::iterator a = ast.algebras.begin(); a != ast.algebras.end(); ++a) {
-		Fn_Def *in_choice_def = (*a).second->choice_fns[(*i).first];
-		Fn_Def *out_choice_def = (*in_choice_def).copy();
-//		out_choice_def->paras.clear();
-//		for (std::list<Para_Decl::Base*>::const_iterator i = (*in_choice_def).paras.begin(); i != (*in_choice_def).paras.end(); ++i) {
-//////		    o->paras.push_back((*i)->copy());
-//		}
-		out_choice_def->name = out_choice_decl->name;
+    // also adding function definition to every algebra
+    for (hashtable<std::string, Algebra*>::iterator a = ast.algebras.begin();
+         a != ast.algebras.end(); ++a) {
+      Fn_Def *in_choice_def = (*a).second->choice_fns[(*i).first];
+      if (in_choice_def) {
+        Fn_Def *out_choice_def = in_choice_def->copy_parameters(
+          out_choice_decl->name);
 
-		// replace whatever function body with list(sum(xs)) ...
-		// ... which will be optimized later into just returning xs
-		out_choice_def->stmts.clear();
-		Expr::Fn_Call *y = new Expr::Fn_Call(Expr::Fn_Call::SUM);
-		y->add(out_choice_def->paras);
-		Expr::Fn_Call *x = new Expr::Fn_Call(Expr::Fn_Call::LIST);
-		x->exprs.push_back(y);
-		out_choice_def->stmts.push_back(new Statement::Return(x));
+        // replace whatever function body with list(sum(xs)) ...
+        // ... which will be optimized later into just returning xs
+        out_choice_def->stmts.clear();
+        Expr::Fn_Call *y = new Expr::Fn_Call(Expr::Fn_Call::SUM);
+        y->add(out_choice_def->paras);
+        Expr::Fn_Call *x = new Expr::Fn_Call(Expr::Fn_Call::LIST);
+        x->exprs.push_back(y);
+        out_choice_def->stmts.push_back(new Statement::Return(x));
 
-		(*a).second->choice_fns[*out_choice_decl->name] = out_choice_def;
-		(*a).second->fns[*out_choice_decl->name] = out_choice_def;
-	}
+        (*a).second->choice_fns[*out_choice_decl->name] = out_choice_def;
+        (*a).second->fns[*out_choice_decl->name] = out_choice_def;
+      } else {
+        Log::instance()->error(
+          "Choice function " + (*i).first + " not defined in algebra "
+          + (*a).first + "!");
+      }
+    }
   }
 
   // replace choice functions of outside NTs
   for (hashtable<std::string, Symbol::Base*>::iterator i = NTs.begin();
          i != NTs.end(); ++i) {
-	Symbol::NT *nt = dynamic_cast<Symbol::NT*>((*i).second);
-	if (nt) {
-		if (nt->is_partof_outside) {
-			if (!(*nt->eval_fn).empty()) {
-				nt->eval_fn = new std::string(PREFIX_DERIVATIVE + *nt->eval_fn);
-			}
-		}
-	}
+    Symbol::NT *nt = dynamic_cast<Symbol::NT*>((*i).second);
+    if (nt) {
+      if (nt->is_partof_outside) {
+        if (!(*nt->eval_fn).empty()) {
+          nt->eval_fn = new std::string(PREFIX_DERIVATIVE + *nt->eval_fn);
+        }
+      }
+    }
   }
+  Log::instance()->verboseMessage(
+    "Choice functions have been modified into 'sum' for outside "
+    "grammar parts in order to compute derivatives.");
 }
-//if (ast.inject_derivatives) {
-//      std::string *CHOICE_FN_NAME = new std::string("stefan");
-//      Fn_Decl *inside_choice_fn = ast.signature->choice_fns.find(*(inside_nt->eval_fn))->second;
-//      assert(inside_choice_fn);
-//      outside_nt->eval_fn = CHOICE_FN_NAME;
-//      if (once == false) {
-//    	  Fn_Decl *outside_choice_fn = new Fn_Decl(*inside_choice_fn);
-//    	  outside_choice_fn->name = CHOICE_FN_NAME;
-//    	  ast.signature->choice_fns[*CHOICE_FN_NAME] = outside_choice_fn;
-//    	  ast.signature->decls[*CHOICE_FN_NAME] = outside_choice_fn;
-//    	  for (hashtable<std::string, Algebra*>::iterator i = ast.algebras.begin(); i != ast.algebras.end(); ++i) {
-//        	  Fn_Def *outside_choice_fn_def = (*i).second->choice_fns[*(inside_nt->eval_fn)]->copy();
-//        	  outside_choice_fn_def->name = CHOICE_FN_NAME;
-//
-//        	  outside_choice_fn_def->types.front() = new Type::List(outside_choice_fn_def->return_type->component());
-//
-//        	  Expr::Fn_Call *x = new Expr::Fn_Call(Expr::Fn_Call::SUM);
-//        	  x->add(outside_choice_fn_def->paras);
-//        	  Expr::Fn_Call *y = new Expr::Fn_Call(Expr::Fn_Call::LIST);
-//        	  y->exprs.push_back(x);
-//        	  std::cerr << (*i).first << ": " << *y << "\n";
-//        	  dynamic_cast<Statement::Return*>(outside_choice_fn_def->stmts.front())->expr = y;
-//
-////        	  Expr::Fn_Call *y = dynamic_cast<Expr::Fn_Call*>(dynamic_cast<Statement::Return*>(outside_choice_fn_def->stmts.front())->expr)->exprs.begin();
-//
-////        	  Statement::Return *x = dynamic_cast<Statement::Return*>(outside_choice_fn_def->stmts.front());
-////        	  Expr::Fn_Call *y = dynamic_cast<Expr::Fn_Call*>(x->expr);
-////        	  dynamic_cast<Expr::Fn_Call*>(y->exprs.front())->builtin = Expr::Fn_Call::SUM;
-//        	  outside_choice_fn_def->set_target_name(*CHOICE_FN_NAME);
-//        	  //outside_choice_fn_def->stmts
-//    		  (*i).second->choice_fns[*CHOICE_FN_NAME] = outside_choice_fn_def;
-//    		  (*i).second->fns[*CHOICE_FN_NAME] = outside_choice_fn_def;
-//    	  }
-//    	  once = true;
-//      }
-//    }
+
+
 unsigned int Grammar::to_dot(unsigned int *nodeID, std::ostream &out,
         int plot_grammar) {
   int start_node;

--- a/src/grammar.hh
+++ b/src/grammar.hh
@@ -48,6 +48,7 @@ class Algebra;
 
 const char OUTSIDE_NT_PREFIX[] = "outside_";
 const char OUTSIDE_AXIOMS[] = "outside_axioms";
+const char PREFIX_DERIVATIVE[] = "derivative_";
 
 class Grammar {
  private:

--- a/src/grammar.hh
+++ b/src/grammar.hh
@@ -228,6 +228,13 @@ class Grammar {
   void inject_outside_nts(std::vector<std::string> outside_nt_list);
   // same as above, without checking user provided NT list
   void inject_outside_nts();
+
+  // replace choice functions in outside rules with list(sum())
+  // when user requested derivative computation, since the computed
+  // values are probabilities, regardless of user transformation like
+  // log- or exp- space
+  void replace_choice_for_derivatives();
+
   unsigned int to_dot(unsigned int *nodeID, std::ostream &out, int plot_level);
 
   // blocks allow alternatives for sub-productions. This function shell free

--- a/src/para_decl.cc
+++ b/src/para_decl.cc
@@ -28,7 +28,6 @@
 
 #include "type/multi.hh"
 
-
 namespace Para_Decl {
 Base::~Base() {
 }
@@ -63,14 +62,17 @@ void Multi::replace(::Type::Base *t) {
 }
 
 
-Base *Simple::copy() const {
+Base *Simple::copy(bool clone_type) const {
   Simple *o = new Simple(*this);
   o->name_ = new std::string(*name_);
+  if (clone_type) {
+    o->type_ = type_->clone();
+  }
   return o;
 }
 
 
-Base *Multi::copy() const {
+Base *Multi::copy(bool clone_type) const {
   Multi *o = new Multi (*this);
   o->list_.clear();
   for (std::list<Simple*>::const_iterator i = list_.begin();
@@ -79,6 +81,11 @@ Base *Multi::copy() const {
     assert(t);
     o->list_.push_back(t);
   }
+  if (clone_type) {
+    o->type_ = type_->clone();
+  }
   return o;
 }
+
+
 }  // namespace Para_Decl

--- a/src/para_decl.hh
+++ b/src/para_decl.hh
@@ -24,6 +24,7 @@
 #ifndef SRC_PARA_DECL_HH_
 #define SRC_PARA_DECL_HH_
 
+#include <algorithm>
 #include <string>
 #include <list>
 
@@ -56,7 +57,7 @@ class Base {
 
   virtual void replace(::Type::Base *t) = 0;
 
-  virtual Base *copy() const = 0;
+  virtual Base *copy(bool clone_type = false) const = 0;
 
   // Returns TRUE if the type of the instance is of a
   // given type.
@@ -84,7 +85,7 @@ class Simple : public Base {
   void replace(::Type::Base *t) { type_ = t; }
   void replace(std::string *n) { name_ = n; }
 
-  Base *copy() const;
+  Base *copy(bool clone_type = false) const;
 };
 
 
@@ -106,7 +107,11 @@ class Multi : public Base {
 
   void replace(::Type::Base *t);
 
-  Base *copy() const;
+  /* if parameter "clone_type" is set to true, types of the copy
+   * will be new objects, not references to the same types as the
+   * template, i.e. this
+   */
+  Base *copy(bool clone_type = false) const;
 };
 
 

--- a/src/tablegen.cc
+++ b/src/tablegen.cc
@@ -519,6 +519,9 @@ Fn_Def *Tablegen::gen_set_traces() {
     new std::string("&traces")), off));
   rhs_norm->add_arg(new std::string("candidates"));
   rhs_norm->add_arg(new std::string("e"));
+  rhs_norm->add_arg(new std::string("&" + *(new std::string(
+    FN_NAME_DERIVATIVE_NORMALIZER))));
+
   Statement::Var_Assign *fn_norm = new Statement::Var_Assign(
     new Var_Acc::Array(new Var_Acc::Plain(new std::string("traces")), off),
     rhs_norm);

--- a/testdata/gapc_filter/negexpsum.hh
+++ b/testdata/gapc_filter/negexpsum.hh
@@ -1,0 +1,38 @@
+#ifndef EXT_HMM_HH
+#define EXT_HMM_HH
+
+template <typename T>
+inline
+T negexpsum(T t) {
+  return t;
+}
+
+template <typename Itr>
+inline
+typename std::iterator_traits<Itr>::value_type negexpsum(Itr begin, Itr end) {
+  typename std::iterator_traits<Itr>::value_type n;
+  if (begin == end) {
+    empty(n);
+    return n;
+  }
+  assert(!isEmpty(*begin));
+  n = exp(-1.0 * *begin);
+  ++begin;
+  for (; begin != end; ++begin) {
+    assert(!isEmpty(*begin));
+    n += exp(-1.0 * *begin);
+  }
+  assert((n > 0 && "Your algebra produces (partial) candidates with negative "
+                   "score, which cannot be logarithmized. Avoid h=negexpsum or "
+                   "ensure all positive values!"));
+  return -1.0 * log(n);
+}
+
+template <typename Iterator>
+inline
+typename std::iterator_traits<Iterator>::value_type
+negexpsum(std::pair<Iterator, Iterator> &p) {
+  return negexpsum(p.first, p.second);
+}
+
+#endif

--- a/testdata/grammar_outside/alignments.gap
+++ b/testdata/grammar_outside/alignments.gap
@@ -63,6 +63,9 @@ algebra alg_similarity implements sig_alignments(alphabet=char, answer=int) {
 }
 
 algebra alg_score implements sig_alignments(alphabet=char, answer=float) {
+  float normalize_derivative(float q, float pfunc) {
+    return q / pfunc;
+  }
   float Ins(<alphabet a, void>, <Subsequence locA, void>, float x) {
     return x * exp(-2.0);
   }

--- a/testdata/grammar_outside/elmamun_derivatives.gap
+++ b/testdata/grammar_outside/elmamun_derivatives.gap
@@ -13,6 +13,9 @@ algebra alg_enum auto enum;
 algebra alg_count auto count;
 
 algebra alg_score implements sig_elmamun(alphabet=char, answer=float) {
+  float normalize_derivative(float q, float pfunc) {
+    return q / pfunc;
+  }
   float number(int value) {
     return 1.0;
   }
@@ -37,6 +40,9 @@ algebra alg_score implements sig_elmamun(alphabet=char, answer=float) {
 } 
 
 algebra alg_hessians implements sig_elmamun(alphabet=char, answer=float) {
+  float normalize_derivative(float q, float pfunc) {
+    return q / pfunc;
+  }
   float number(int value) {
     return 0.0;
   }

--- a/testdata/grammar_outside/hmm_sonneregen_properEnd.gap
+++ b/testdata/grammar_outside/hmm_sonneregen_properEnd.gap
@@ -1,3 +1,5 @@
+import negexpsum
+
 type Rope = extern
 
 signature sig_weather(alphabet, answer) {
@@ -131,6 +133,115 @@ algebra alg_fwd extends alg_viterbi {
     return list(sum(candidates));
   }
 }
+
+algebra alg_fwd_log implements sig_weather(alphabet=char, answer=float) {
+  float transition_start_hoch(float transition, float emission, float x) {
+    return log(transition) + emission + x;
+  }
+  float transition_start_tief(float transition, float emission, float x) {
+    return log(transition) + emission + x;
+  }
+  float transition_start_ende(float transition, float x) {
+    return log(transition) + x;
+  }
+  float transition_hoch_tief(float transition, float emission, float x) {
+    return log(transition) + emission + x;
+  }
+  float transition_hoch_hoch(float transition, float emission, float x) {
+    return log(transition) + emission + x;
+  }
+  float transition_hoch_ende(float transition, float x) {
+    return log(transition) + x;
+  }
+  float transition_tief_tief(float transition, float emission, float x) {
+    return log(transition) + emission + x;
+  }
+  float transition_tief_hoch(float transition, float emission, float x) {
+    return log(transition) + emission + x;
+  }
+  float transition_tief_ende(float transition, float x) {
+    return log(transition) + x;
+  }
+  
+  float emission_hoch_sonne(float emission, char a) {
+    return log(emission);
+  }
+  float emission_hoch_regen(float emission, char a) {
+    return log(emission);
+  }
+  float emission_tief_sonne(float emission, char a) {
+    return log(emission);
+  }
+  float emission_tief_regen(float emission, char a) {
+    return log(emission);
+  }
+  float nil(void) {
+    return log(1.0);
+  }
+
+  float normalize_derivative(float q, float pfunc) {
+    return exp(q - pfunc);
+  }
+
+  choice [float] h([float] candidates) {
+    return list(expsum(candidates));
+  }
+}
+
+algebra alg_fwd_neglog implements sig_weather(alphabet=char, answer=float) {
+  float transition_start_hoch(float transition, float emission, float x) {
+    return log(1.0/transition) + emission + x;
+  }
+  float transition_start_tief(float transition, float emission, float x) {
+    return log(1.0/transition) + emission + x;
+  }
+  float transition_start_ende(float transition, float x) {
+    return log(1.0/transition) + x;
+  }
+  float transition_hoch_tief(float transition, float emission, float x) {
+    return log(1.0/transition) + emission + x;
+  }
+  float transition_hoch_hoch(float transition, float emission, float x) {
+    return log(1.0/transition) + emission + x;
+  }
+  float transition_hoch_ende(float transition, float x) {
+    return log(1.0/transition) + x;
+  }
+  float transition_tief_tief(float transition, float emission, float x) {
+    return log(1.0/transition) + emission + x;
+  }
+  float transition_tief_hoch(float transition, float emission, float x) {
+    return log(1.0/transition) + emission + x;
+  }
+  float transition_tief_ende(float transition, float x) {
+    return log(1.0/transition) + x;
+  }
+  
+  float emission_hoch_sonne(float emission, char a) {
+    return log(1.0/emission);
+  }
+  float emission_hoch_regen(float emission, char a) {
+    return log(1.0/emission);
+  }
+  float emission_tief_sonne(float emission, char a) {
+    return log(1.0/emission);
+  }
+  float emission_tief_regen(float emission, char a) {
+    return log(1.0/emission);
+  }
+  float nil(void) {
+    return log(1.0/1.0);
+  }
+
+  float normalize_derivative(float q, float pfunc) {
+    return exp(pfunc - q);
+  }
+
+  synoptic choice [float] h([float] candidates) {
+    return list(negexpsum(candidates));
+  }
+}
+
 
 algebra alg_states implements sig_weather(alphabet=char, answer=Rope) {
   Rope transition_start_hoch(float transition, Rope emission, Rope x) {
@@ -355,4 +466,6 @@ grammar gra_weather uses sig_weather(axiom=start) {
 instance enum = gra_weather(alg_enum);
 instance viterbistatesmult = gra_weather(alg_viterbi * alg_states * alg_mult);
 instance fwd = gra_weather(alg_fwd);
+instance fwd_log = gra_weather(alg_fwd_log);
+instance fwd_neglog = gra_weather(alg_fwd_neglog);
 instance multviterbistates = gra_weather(alg_mult * alg_viterbi * alg_states);

--- a/testdata/grammar_outside/hmm_sonneregen_properEnd.gap
+++ b/testdata/grammar_outside/hmm_sonneregen_properEnd.gap
@@ -124,6 +124,9 @@ algebra alg_experiment implements sig_weather(alphabet=char, answer=float) {
 }
 
 algebra alg_fwd extends alg_viterbi {
+  float normalize_derivative(float q, float pfunc) {
+    return q / pfunc;
+  }
   choice [float] h([float] candidates) {
     return list(sum(candidates));
   }

--- a/testdata/grammar_outside/nodangle.gap
+++ b/testdata/grammar_outside/nodangle.gap
@@ -64,6 +64,9 @@ algebra alg_mfe implements sig_foldrna(alphabet = char, answer = int) {
 }
 
 algebra alg_pfunc implements sig_foldrna(alphabet = char, answer = double) {
+  float normalize_derivative(float q, float pfunc) {
+    return q / pfunc;
+  }
   double sadd(Subsequence lb, double x) {
     return scale(1) *                     x * mk_pf(sbase_energy());
   }

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -496,5 +496,10 @@ check_new_old_eq_twotrack alignments.gap unused firstD "frzeitei" nwjamiederiv "
 check_new_old_eq_twotrack alignments.gap unused firstD_gotoh "freizunt" gotohderiv "frnt"
 check_new_old_eq nodangle.gap unused pfunc "GCaaaGC" nodanglederiv
 check_new_old_eq nodangle.gap unused pfunc "CCaCCaaaGGaCCaaaGGaCCaaaGGaGG" nodanglederivlong
+
 # results of the below HMM where extensively validated by Stefan via Excel and python implementations
-check_new_old_eq hmm_sonneregen_properEnd.gap unused fwd "SSRR" sonneregen1deriv
+# tests for special "normalize_derivative" algebra function
+CPPFLAGS_EXTRA="$DEFAULT_CPPFLAGS_EXTRA"  # for negexpsum function, defined as external *.hh file
+check_new_old_eq hmm_sonneregen_properEnd.gap unused fwd "SSRR" sonneregen1deriv # probs - sum
+check_new_old_eq hmm_sonneregen_properEnd.gap unused fwd_log "SSRR" sonneregen1deriv_log # log - expsum
+check_new_old_eq hmm_sonneregen_properEnd.gap unused fwd_neglog "SSRR" sonneregen1deriv_neglog # neglog - negexpsum


### PR DESCRIPTION
This PR adds two functionalities:
1) regardless of the defined choice function for the inside pass, the outside pass requires the synoptic `sum` of candidates. Thus, we automatically replace the choice function(s) for outside pass such that also type optimizations e.g. [float] -> float will be applied
2) weight of incoming edges (q) must be normalized into probabilities. If user defined algebra uses probabilities itself (and sum as choice function), normalization is just q / sum(q). However, if user converted e.g. into log-space for better numeric stability correct normalization will require exp(q - sum(q)) and expsum as inside choice function. With this PR, gapc will check for presence of a special function `const char FN_NAME_DERIVATIVE_NORMALIZER[] = "normalize_derivative";` in algebra definition if code generation for first derivatives is requested and uses this function for normalization.