### PR TITLE
Plot optional non-terminal parameters

### DIFF
--- a/src/alt.cc
+++ b/src/alt.cc
@@ -3077,6 +3077,7 @@ unsigned int* Alt::Base::to_dot(unsigned int *nodeID, std::ostream &out,
       out << ".[ ";
     }
     out << *simple->name;
+    simple->ntparas_to_dot(out);
     if (simple->has_index_overlay()) {
       out << " ].";
     }
@@ -3099,6 +3100,7 @@ unsigned int* Alt::Base::to_dot(unsigned int *nodeID, std::ostream &out,
   }
   if (link) {
     out << "<td>" << *link->name;
+    link->ntparas_to_dot(out);
   }
   Alt::Block *block = dynamic_cast<Alt::Block*>(this);
   if (block) {
@@ -3240,4 +3242,37 @@ unsigned int* Alt::Multi::to_dot(unsigned int *nodeID, std::ostream &out,
   // return not the cluster ID but the id of the first element
   return res;
 }
+
+void Alt::Base::ntparas_to_dot(std::ostream &out) {
+  throw LogError("Non-terminal parameter list cannot be plotted to graphViz!");
+}
+void Alt::Simple::ntparas_to_dot(std::ostream &out) {
+  if (this->ntparas.size() > 0) {
+    out << " (";
+  }
+  for (std::list<Expr::Base*>::const_iterator ip = this->ntparas.begin();
+       ip != this->ntparas.end(); ++ip) {
+    out << *(*ip);
+    if (std::next(ip) != this->ntparas.end()) {
+      out << ", ";
+    }
+  }
+  if (this->ntparas.size() > 0) {
+    out << ")";
+  }
+}
+void Alt::Link::ntparas_to_dot(std::ostream &out) {
+  if (this->ntparas.size() > 0) {
+    out << " (";
+  }
+  for (std::list<Expr::Base*>::const_iterator ip = this->ntparas.begin();
+       ip != this->ntparas.end(); ++ip) {
+    out << *(*ip);
+    if (std::next(ip) != this->ntparas.end()) {
+      out << ", ";
+    }
+  }
+  if (this->ntparas.size() > 0) {
+    out << ")";
+  }}
 // END functions produce graphViz code to represent the grammar

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -3274,5 +3274,6 @@ void Alt::Link::ntparas_to_dot(std::ostream &out) {
   }
   if (this->ntparas.size() > 0) {
     out << ")";
-  }}
+  }
+}
 // END functions produce graphViz code to represent the grammar

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -307,6 +307,9 @@ class Base {
 
   virtual void set_ntparas(const Loc &loc, std::list<Expr::Base*> *l);
 
+  // generates graphviz code to represent NT-parameters
+  virtual void ntparas_to_dot(std::ostream &out);
+
   bool choice_set();
   unsigned int to_dot_semanticfilters(unsigned int *nodeID, unsigned int thisID,
     std::ostream &out, std::vector<unsigned int> *childIDs = NULL);
@@ -490,6 +493,7 @@ class Simple : public Base {
 
  public:
   void set_ntparas(std::list<Expr::Base*> *l);
+  void ntparas_to_dot(std::ostream &out);
   unsigned int* to_dot(unsigned int *nodeID, std::ostream &out,
           int plot_level);
 
@@ -611,6 +615,7 @@ class Link : public Base {
 
  public:
   void set_ntparas(const Loc &loc, std::list<Expr::Base*> *l);
+  void ntparas_to_dot(std::ostream &out);
   bool check_ntparas();
 
   void optimize_choice();


### PR DESCRIPTION
Algebra functions can have additional parameters as further inputs besides sub-parses, see https://github.com/jlab/gapc/blob/master/testdata/grammar/empty_ys_issue_larger.gap or https://github.com/jlab/gapc/blob/master/testdata/grammar/pknotsRG.gap for examples. Signature, grammar, and algebra definitions look like this:
```
answer right_transition(float, answer, alphabet; int);
```
```
right_transition(CONST_FLOAT(-1.823000), state_IR_19, CHAR; 19)
```
```
  float right_transition(float tsc, float x, alphabet a; int pos) {
    return tsc + getEmission(pos, a) + x;
  }
```
These parameters are currently **not** printed into the out.dot file when `gapc` is invoked with the `plot-grammar X` command line argument. A resulting PDF currently looks like:
![image](https://user-images.githubusercontent.com/11960616/213655290-30d9de33-d655-4d14-bb3c-3bc358229b81.png)

With this PR the updated graphic should include the parameters enclosed in parenthesis:
![image](https://user-images.githubusercontent.com/11960616/213655390-588d90a3-374c-4e8c-80bd-81f654b35a86.png)
