### PR TITLE
"complete_track" ->"minsize(0)" / "maxsize(0)

### DIFF
--- a/rtlib/filter.hh
+++ b/rtlib/filter.hh
@@ -127,10 +127,4 @@ inline bool samesize(const Basic_Sequence<a1, pos_type> &s1,
   return j1-i1 == j2-i2;
 }
 
-template<typename alphabet, typename pos_type, typename T>
-inline bool complete_track(
-    const Basic_Sequence<alphabet, pos_type> &seq, T i, T j) {
-  return ((i == seq.n) && (j == seq.n));
-}
-
 #endif  // RTLIB_FILTER_HH_

--- a/rtlib/filter.hh
+++ b/rtlib/filter.hh
@@ -127,4 +127,10 @@ inline bool samesize(const Basic_Sequence<a1, pos_type> &s1,
   return j1-i1 == j2-i2;
 }
 
+template<typename alphabet, typename pos_type, typename T>
+inline bool end_of_track(
+    const Basic_Sequence<alphabet, pos_type> &seq, T i, T j) {
+  return ((i == seq.n) && (j == seq.n));
+}
+
 #endif  // RTLIB_FILTER_HH_


### PR DESCRIPTION
in preparation of yield size computation, I switch from agnostic `complete_track` filter to yield size observing built in `min_size(0) && max_size(0)` for the additional alternative from an outside NT to the inside axiom