### PR TITLE
Plotgrammar add ys tabdim

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -51,6 +51,8 @@ jobs:
       run: make test-unit
     # we need to install Haskell (especially the System.Random lib) for paralell tests, since we compare Haskell ADP with gapc
     - uses: haskell/actions/setup@v2
+      with:
+        cabal-version: '3.6.2.0'  # pin version on 2023-02-09 to enable proper cabal installtion
       id: haskell
     - name: cabal
       run: |

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -2972,6 +2972,20 @@ void to_dot_indices(std::vector<Expr::Base*> indices, std::ostream &out) {
   }
   out << "</font></td>";
 }
+void to_dot_multiys(Yield::Multi m_ys, std::ostream &out) {
+  // one additional line per track for minimum and maximum yield size
+  unsigned int track = 0;
+  for (Yield::Multi::iterator ys = m_ys.begin(); ys != m_ys.end();
+       ++ys, ++track) {
+    out << "<tr>";
+    out << "<td colspan=\"3\">yield size";
+    if (m_ys.tracks() > 1) {
+      out << " (track " << track << ")";
+    }
+    out << ": " << *ys << "</td>";
+    out << "</tr>";
+  }
+}
 void to_dot_filternameargs(Filter *filter, std::ostream &out) {
   out << *filter->name;
   for (std::list<Expr::Base*>::const_iterator arg = filter->args.begin();
@@ -3125,7 +3139,11 @@ unsigned int* Alt::Base::to_dot(unsigned int *nodeID, std::ostream &out,
       to_dot_indices(this->right_indices, out);
     }
   }
-  out << "</tr></table>>, color=\"";
+  out << "</tr>";
+  if (plot_grammar > 3) {
+    to_dot_multiys(m_ys, out);
+  }
+  out << "</table>>, color=\"";
   if (simple) {
     if (simple->is_terminal()) {
       out << "blue";

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -770,4 +770,8 @@ class Multi : public Base {
 // used as a helper for to_dot functions
 void to_dot_indices(std::vector<Expr::Base*> indices, std::ostream &out);
 
+// adds further lines (one per track) to indicate yield sizes of
+// grammar components
+void to_dot_multiys(Yield::Multi m_ys, std::ostream &out);
+
 #endif  // SRC_ALT_HH_

--- a/src/gapc.cc
+++ b/src/gapc.cc
@@ -134,6 +134,8 @@ static void parse_options(int argc, char **argv, Options *rec) {
       "  1 = grammar\n"
       "  2 = add indices\n"
       "  3 = add data types.\n"
+      "  4 = add min/max yield sizes.\n"
+      "  5 = add non-terminal table dimensions.\n"
       "(Use 'dot -Tpdf out.dot' to generate a PDF.)\nDefault file is out.dot");
   po::options_description hidden("");
   hidden.add_options()

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -1643,7 +1643,27 @@ unsigned int Symbol::Base::to_dot(unsigned int *nodeID, std::ostream &out,
     }
     out << "</td>";
     to_dot_indices(this->right_indices, out);
-    out << "</tr></table>>";
+    out << "</tr>";
+    if (plot_grammar > 3) {
+      to_dot_multiys(this->m_ys, out);
+    }
+    if (plot_grammar > 4) {
+      // print table dimensions ...
+      Symbol::NT *nt = dynamic_cast<Symbol::NT*>(this);
+      if (nt) {
+        // .. if Symbol is Non-terminal
+        out << "<tr><td colspan=\"3\">";
+        for (std::vector<Table>::const_iterator t = nt->tables().begin();
+             t != nt->tables().end(); ++t) {
+          (*t).print(out);
+          if (std::next(t) != nt->tables().end()) {
+            out << " ";
+          }
+        }
+        out << "</td></tr>";
+      }
+    }
+    out << "</table>>";
   } else {
     out << "<td>" << *this->name << "</td></tr></table>>";
   }

--- a/testdata/modtest/multi_plot_grammar_level3.cc
+++ b/testdata/modtest/multi_plot_grammar_level3.cc
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
   grammar->dep_analysis();
 
   unsigned int nodeID = 1;
-  int plot_level = 99;
+  int plot_level = 3;
   grammar->to_dot(&nodeID, std::cout, plot_level);
   return 0;
 }

--- a/testdata/modtest/multi_plot_grammar_level5.cc
+++ b/testdata/modtest/multi_plot_grammar_level5.cc
@@ -1,0 +1,88 @@
+// Copyright 2022 stefan.m.janssen@gmail.com
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cassert>
+
+#include "../../src/driver.hh"
+#include "../../src/log.hh"
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "Call " << *argv << " *.gap-file\n";
+    return 1;
+  }
+
+  std::ostringstream o;
+  Log log;
+  log.set_debug(false);
+  log.set_ostream(o);
+
+  Driver driver;
+
+  // === front
+  // set the file name of the gap-source-code
+  std::string filename(argv[1]);
+  driver.setFilename(filename);
+
+  // parses the input file and builds the AST
+  driver.parse();
+  if (driver.is_failing()) {
+    return 4;
+  }
+
+  // simply gets the selected grammar, which is either the
+  // grammar that occurred first in the source code or is the
+  // one that was named in the parameters on the command line
+  Grammar *grammar = driver.ast.grammar();
+  // Now check the semantic, which does more than the function
+  // name suggests. The semantic check is embedded in the algorithm
+  // that links the grammar graph together, and computes yield-sizes.
+  // If the method returns false, there are some semantic errors,
+  // which leads to the end of the compilation process.
+  bool r = grammar->check_semantic();
+  if (!r) {
+    return 2;
+  }
+
+  // set approx table design
+  grammar->approx_table_conf();
+
+  // find what type of input is read
+  // chars, sequence of ints etc.
+  driver.ast.derive_temp_alphabet();
+
+  try {
+    r = driver.ast.check_signature();
+    if (!r) {
+      return 3;
+    }
+  } catch (LogThreshException) {
+    return 9;
+  }
+
+  if (driver.ast.first_instance == NULL) {
+    return 11;
+  }
+  r = driver.ast.check_instances(driver.ast.first_instance);
+  if (!r)
+    return 10;
+
+  // apply this to identify standard functions like Min, Max, Exp etc.
+  driver.ast.derive_roles();
+
+
+  // ------------- back ------------
+  grammar->init_list_sizes();
+
+  grammar->init_indices();
+  grammar->init_decls();
+  // for cyk (ordering of NT for parsing, see page 101 of the thesis)
+  grammar->dep_analysis();
+
+  unsigned int nodeID = 1;
+  int plot_level = 5;
+  grammar->to_dot(&nodeID, std::cout, plot_level);
+  return 0;
+}


### PR DESCRIPTION
I am extending the level of detail for generating graphViz code about the used grammar. Two additional levels can be selected by the user with this PR:
4) which will also add one line per track for the minimal and maximal yield size of each grammar component. The yield size determines how many terminals can be parsed at least = minimal and at most = maximal, which can be `n` if infinite terminals are consumable
5) lhs non-terminal symbols will have additional lines describing the table layout necessary for tabulation (and on demand computation) like quadratic (default), linear or constant tables.

I also re-design the gold standards for plot-grammar functionality. We now have three levels tested: 1, 3, 5. Instead of 1 and `full` as before, since full was too unspecific and probably makes further development more complicated.

P.S. I don't know why cabal 3.8.1.0 installation today fails on github actions ubuntu images. Thus I pinned an earlier one