### PR TITLE
proper align non terminals in grammar plots

### DIFF
--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -38,6 +38,20 @@ static const char *COLOR_NONTERMINAL = "black";
 static const char *COLOR_BLOCK = "gray";
 static const char *COLOR_EVALFCT = "purple";
 
+static const bool HIDEINVISIBLE = true;
+
+std::string make_insivible(bool singlearg) {
+  if (!HIDEINVISIBLE) {
+    return "";
+  } else {
+    if (singlearg) {
+      return "style=\"invis\"";
+    } else {
+      return "style=\"invis\", ";
+    }
+  }
+}
+
 // the following functions produce graphViz code to represent the grammar
 void Alt::Link::to_dot_overlayindices(std::ostream &out, bool is_left_index) {
   out << "<td><font point-size='8' color='" << COLOR_OVERLAY << "'><b>";
@@ -342,7 +356,7 @@ unsigned int* Alt::Multi::to_dot(unsigned int *nodeID, std::ostream &out,
     childIDs->push_back(childID[0]);
     if (lastID > 0) {
       out << "    node_" << lastID << " -> node_" << childID[0]
-          << " [ style=\"invis\" ];\n";
+          << " [ " << make_insivible(true) << " ];\n";
     }
     lastID = childID[0];
   }
@@ -476,7 +490,7 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
       sepNodeID = (unsigned int)((*nodeID)++);
       // add an invisible edge from lhs NT to --> node
       out << "    node_" << thisID << " -> node_" << sepNodeID
-          << " [ style=invis, weight=99 ];\n";
+          << " [ " << make_insivible(false) << "weight=99 ];\n";
       // adding a separator node to draw the --> arrow from lhs NT
       // name to alternatives
       out << "    node_" << sepNodeID << " [ label=<<table border='0'><tr>"
@@ -485,7 +499,7 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
       // add an invisible edge from the --> node to the first
       // alternative production
       out << "    node_" << sepNodeID << " -> node_" << *nodeID
-          << " [ style=invis ];\n";
+          << " [ " << make_insivible(true) << " ];\n";
       rank += "node_" + std::to_string(sepNodeID) + " ";
     }
     for (std::list<Alt::Base*>::const_iterator alt = this->alts.begin();
@@ -504,12 +518,12 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
         // incoming and outgoing invisible edges
         sepNodeID = (unsigned int)((*nodeID)++);
         out << "    node_" << childID << " -> node_" << sepNodeID
-            << " [ style=invis ];\n";
+            << " [ " << make_insivible(true) << " ];\n";
         out << "    node_" << sepNodeID << " [ label=<<table border='0'>"
             << "<tr><td><font point-size='30'>|</font></td></tr></table>>"
             << ", shape=plaintext ];\n";
         out << "    node_" << sepNodeID << " -> node_" << *nodeID
-            << " [ style=invis ];\n";
+            << " [ " << make_insivible(true) << " ];\n";
         rank += "node_" + std::to_string(sepNodeID) + " ";
       }
     }
@@ -547,9 +561,10 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
     anchorID = choiceID;
     for (unsigned int depth = lhsNT_depth; depth < max_depth; depth++) {
       out << "    node_" << anchorID << " -> node_" << *nodeID
-          << " [ style=invis, weight=99 ];\n";
+          << " [ " << make_insivible(false) << "weight=99 ];\n";
       anchorID = (unsigned int)((*nodeID)++);
-      out << "    node_" << anchorID << " [ style=invis ];\n";
+      out << "    node_" << anchorID << " [ "
+          << make_insivible(true) << " ];\n";
     }
 
     out << "    { rank=same node_" << thisID << " " << rank << "}\n";
@@ -575,7 +590,7 @@ unsigned int Grammar::to_dot(unsigned int *nodeID, std::ostream &out,
       // invisible edges from the anchor to the lhs non-terminal node of the
       // next unit to enable vertical alignment
       out << "node_" << start_node << " -> node_" << std::to_string(*nodeID)
-          << " [ style=invis ];\n";
+          << " [ " << make_insivible(true) << " ];\n";
     }
     // let's organize all nodes of a lhs non-terminal in one subgraph cluster
     // such that it can be plotted as one unit and these units are

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -594,15 +594,22 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
      * node is on the same rank.
      * Note: it is important that the anchor node has a rectangular shape, we
      *       also want to make it as small as possible to not shift visible
-     *       nodes unneccesarily far to the right*/
-    if (max_depth > 1) {
-      anchorID = (unsigned int)((*nodeID)++);
-      out << "    node_" << anchorID << " [ " << make_insivible(false)
-          << "shape=box, fixedsize=true, width=0.01, label=\"\" ];\n";
+     *       nodes unnecessarily far to the right
+     * Further note: if lhs and rhs have only one level, the anchor is the lhs
+     *               NT node. No additional node must be added.
+     */
+    if (max_depth > 0) {
+      if (deepest_nodeID == 0) {
+        anchorID = thisID;
+      } else {
+        anchorID = (unsigned int)((*nodeID)++);
+        out << "    node_" << anchorID << " [ " << make_insivible(false)
+            << "shape=box, fixedsize=true, width=0.01, label=\"\" ];\n";
+        out << "    { rank=same node_" << anchorID << " node_" << deepest_nodeID
+            << "}\n";
+      }
       out << "    node_" << thisID << ":sw -> node_" << anchorID << ":nw ["
           << make_insivible(false) << "weight=999 ];\n";
-      out << "    { rank=same node_" << anchorID << " node_" << deepest_nodeID
-          << "}\n";
     }
 
     out << "    { rank=same node_" << thisID << " " << rank << "}\n";

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -378,7 +378,8 @@ unsigned int* Alt::Multi::to_dot(unsigned int *nodeID, std::ostream &out,
     lastID = childID[0];
   }
   // add syntactic filter and draw an edge to every track component
-  unsigned int filter_nodeID = to_dot_semanticfilters(nodeID, thisID, out, childIDs);
+  unsigned int filter_nodeID = to_dot_semanticfilters(
+      nodeID, thisID, out, childIDs);
   if (filter_nodeID > 0) {
     // semantic filter can at most add one new level of nodes as all filters
     // will populate the same level. If no filter is present, no new layer

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -609,6 +609,7 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
         out << "    { rank=same node_" << anchorID << " node_" << deepest_nodeID
             << "}\n";
       }
+      assert(anchorID != 0);
       out << "    node_" << thisID << ":sw -> node_" << anchorID << ":nw ["
           << make_insivible(false) << "weight=999 ];\n";
     }

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -496,7 +496,7 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
   unsigned int anchorID = 0;
   unsigned int max_depth = 1;
   unsigned int deepest_nodeID = 0;
-  unsigned int *res = (unsigned int *) malloc(2 * sizeof(int));
+  unsigned int *res = (unsigned int *) malloc(3 * sizeof(int));
   // with "rank" we collect nodes that must be drawn topmost in a cluster
   std::string rank = "";
   out << ", color=\"" << COLOR_NONTERMINAL << "\"";
@@ -580,6 +580,11 @@ unsigned int Symbol::NT::to_dot(unsigned int *nodeID, std::ostream &out,
       // choice function will be located on depth+1, i.e. one less
       // invisible fake node necessary
       lhsNT_depth++;
+
+      if (lhsNT_depth > max_depth) {
+        deepest_nodeID = choiceID;
+        max_depth = lhsNT_depth;
+      }
     }
 
     /* In order to align each NT vertically below each other, we inject one


### PR DESCRIPTION
In current grammar plots `--plot-grammar 1`, the alignment of the non-terminals, which are placed below each other, is not properly left aligned, e.g.
![image](https://user-images.githubusercontent.com/11960616/225317959-d735f828-24c3-4945-a2b3-915937759626.png)

This PR uses a different mechanism to inject invisible nodes to force the layout of `dot` to almost perfectly left align all `subgraphs`. We therefore place only one invisible node at the lowest rank per non-terminal, connect this node a) with the lhs non-terminal node and b) with the next lhs non-terminal of the following subgraph. It is important to make the shape rectangular and use proper `ports` for the edge connection, i.e. `sw` to `nw`. We therefore have to return the nodeID of one of the lowest nodes per non-terminal subgraph in addition to the already returned `max_depth`. The result looks visually more pleasing:

![image](https://user-images.githubusercontent.com/11960616/225317930-0bd5f7b5-8228-4188-89de-94bc3272c17d.png)

However, these changes will require updates of all "truth" files in the gapc-test-suite