### PR TITLE
Refactor plotgrammar order

### DIFF
--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -90,9 +90,9 @@ void legend(unsigned int nodeID, std::ostream &out, int plot_grammar) {
   out << indent() << "ln_block [ label=\"block\", color=\""
       << COLOR_BLOCK << "\" ];\n";
   out << indent() << "ln_lhs_nt_tab [ label=\"tabulated\", color=\""
-      << COLOR_NONTERMINAL << "\", shape=\"box\", style=\"dotted\" ];\n";
-  out << indent() << "ln_lhs_nt_nontab [ label=\"not tabulated\", color=\""
       << COLOR_NONTERMINAL << "\", shape=\"box\" ];\n";
+  out << indent() << "ln_lhs_nt_nontab [ label=\"not tabulated\", color=\""
+      << COLOR_NONTERMINAL << "\", shape=\"box\", style=\"dotted\" ];\n";
   out << indent() << "ln_filter [ label=\"filter\", fontcolor=\""
       << COLOR_FILTER << "\", shape=none ];\n";
   out << indent() << "ln_choice [ label=\"evaluation function\", fontcolor=\""


### PR DESCRIPTION
I hope to finally have found a way to preserve child node ordering when plotting a grammar by wrapping each alternative into it's own `subgraph cluster`. For unknown reasons, ordering of alternatives is then reversed, i.e. we have to reverse iterate through them.
I've also added a legend at the bottom of a graph and the name of the grammar as label to the top.
Master:
![image](https://user-images.githubusercontent.com/11960616/231231293-eeebb11c-7c70-4037-bedf-54b8a51f76a6.png)
This PR:
![image](https://user-images.githubusercontent.com/11960616/231231353-818f576f-b56b-45db-88d3-f678af5189c2.png)

