### PR TITLE
fix wrong variable name

### DIFF
--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -2084,7 +2084,7 @@ void Printer::Cpp::print_openmp_cyk(const AST &ast) {
            << "z : inner_loop_2_idx_start;"
            << " y < max_tiles_n; y+=tile_size) {" << endl;
     inc_indent();
-    stream << indent() << "++y_loaded;" << endl;
+    stream << indent() << "++inner_loop_2_idx_loaded;" << endl;
     stream << indent() << "mutex.lock_shared();" << endl;
   } else {
     stream << indent()


### PR DESCRIPTION
This PR should fix the bug from [this issue](https://github.com/jlab/gapc/issues/196).