### PR TITLE
set yield size of CONST_ terminal parser to (0,0)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip
 
     - name: Checkout truth
-      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch flag_const_inject_terminal_args https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure
@@ -79,7 +79,7 @@ jobs:
     - name: add random Haskell lib
       run: cabal install --lib random
     - name: Checkout truth
-      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch flag_const_inject_terminal_args https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip
 
     - name: Checkout truth
-      run: git clone --branch flag_const_inject_terminal_args https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure
@@ -79,7 +79,7 @@ jobs:
     - name: add random Haskell lib
       run: cabal install --lib random
     - name: Checkout truth
-      run: git clone --branch flag_const_inject_terminal_args https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure

--- a/src/fn_arg.cc
+++ b/src/fn_arg.cc
@@ -42,13 +42,11 @@ Fn_Arg::Base::~Base() {}
 
 
 Fn_Arg::Const::Const(::Const::Base *e, const Loc &l,
-                     const std::string &child_token)
-  : Base(CONST, l), expr_(e) {
+                     const bool is_inject_argument)
+  : Base(CONST, l), expr_(e), is_inject_argument(is_inject_argument) {
   productive = true;
   terminal_type = true;
   list_size_ = 1;
-
-  is_inject_argument = (child_token.rfind("CONST_") == 0);
 
   init_multi_ys();
 }

--- a/src/fn_arg.cc
+++ b/src/fn_arg.cc
@@ -41,11 +41,14 @@ Fn_Arg::Base::Base(Type t, const Loc &l)
 Fn_Arg::Base::~Base() {}
 
 
-Fn_Arg::Const::Const(::Const::Base *e, const Loc &l)
+Fn_Arg::Const::Const(::Const::Base *e, const Loc &l,
+                     const std::string &child_token)
   : Base(CONST, l), expr_(e) {
   productive = true;
   terminal_type = true;
   list_size_ = 1;
+
+  is_inject_argument = (child_token.rfind("CONST_") == 0);
 
   init_multi_ys();
 }
@@ -417,7 +420,9 @@ void Fn_Arg::Alt::print(std::ostream &s) {
 
 void Fn_Arg::Const::init_multi_ys() {
   m_ys.set_tracks(1);
-  m_ys(0) = expr_->yield_size();
+  if (!is_inject_argument) {
+    m_ys(0) = expr_->yield_size();
+  }
 }
 const Yield::Multi &Fn_Arg::Alt::multi_ys() const {
   return alt->multi_ys();

--- a/src/fn_arg.hh
+++ b/src/fn_arg.hh
@@ -208,7 +208,7 @@ class Const : public Base {
     bool is_inject_argument;
 
  public:
-    Const(::Const::Base *e, const Loc &l, const std::string &child_token);
+    Const(::Const::Base *e, const Loc &l, const bool is_inject_argument);
 
     Base *clone();
 

--- a/src/fn_arg.hh
+++ b/src/fn_arg.hh
@@ -202,8 +202,13 @@ class Const : public Base {
     Yield::Poly list_size_;
     ::Const::Base *expr_;
 
+    /* true for CONST_* terminal parser, which do NOT actually consume subwords
+     * of the input sequence, e.g. CONST_FLOAT(0.5), as opposed to parameterized
+     * terminal parser like CHAR('A'). */
+    bool is_inject_argument;
+
  public:
-    Const(::Const::Base *e, const Loc &l);
+    Const(::Const::Base *e, const Loc &l, const std::string &child_token);
 
     Base *clone();
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -1670,7 +1670,8 @@ rhs_arg: alt /* NT or block ... */
           * a) is a parameterized terminal e.g. CHAR('x') or
           * b) injects an argument to the algebra function without
           *    parse anything */
-         { $$ = new Fn_Arg::Const($1, @1, *$<sval>0); } /* term parse arg */ ;
+         /* term parse arg */
+         { $$ = new Fn_Arg::Const($1, @1, $<sval>0->rfind("CONST_") == 0); } ;
 
 /* for consts as arguments in terminal parsers */
 const: number { $$ = $1;} |

--- a/src/parser.y
+++ b/src/parser.y
@@ -1666,7 +1666,11 @@ rhs_args: rhs_arg
 rhs_arg: alt /* NT or block ... */
          { $$ = new Fn_Arg::Alt($1, @1); } |
          const
-         { $$ = new Fn_Arg::Const($1, @1); } /* term parse arg */ ;
+         /* smj: also pass child token ($<sval>0) to infer if the constant
+          * a) is a parameterized terminal e.g. CHAR('x') or
+          * b) injects an argument to the algebra function without
+          *    parse anything */
+         { $$ = new Fn_Arg::Const($1, @1, *$<sval>0); } /* term parse arg */ ;
 
 /* for consts as arguments in terminal parsers */
 const: number { $$ = $1;} |

--- a/src/specialize_grammar/create_specialized_grammar.cc
+++ b/src/specialize_grammar/create_specialized_grammar.cc
@@ -397,7 +397,7 @@ std::pair<Alt::Base*, SpecializeGrammar::CreateSpecializedGrammar::
         this->algebraFunctionInfoAttribute = attribute;
       }
 
-      // OMG, once again a spacial case handled here!
+      // OMG, once again a special case handled here!
       // If this is a wrapped non-terminal, just create directly an algebra
       // function for it. We need to do this here, because the wrapper
       // itself is needed as the root node for the createAlgebraFunction
@@ -476,7 +476,7 @@ std::pair<Alt::Base*, SpecializeGrammar::CreateSpecializedGrammar::
         Alt::Simple* simple = new Alt::Simple(
           new std::string("CHAR"), location);
         Fn_Arg::Const* parameter = new Fn_Arg::Const(
-          new ::Const::Char(terminalValue->at(0)), location);
+          new ::Const::Char(terminalValue->at(0)), location, "dummy");
         // This is the list of arguments we pass to the GAP AST algebra
         // function application.
         std::list<Fn_Arg::Base*> args;

--- a/src/specialize_grammar/create_specialized_grammar.cc
+++ b/src/specialize_grammar/create_specialized_grammar.cc
@@ -476,7 +476,7 @@ std::pair<Alt::Base*, SpecializeGrammar::CreateSpecializedGrammar::
         Alt::Simple* simple = new Alt::Simple(
           new std::string("CHAR"), location);
         Fn_Arg::Const* parameter = new Fn_Arg::Const(
-          new ::Const::Char(terminalValue->at(0)), location, "dummy");
+          new ::Const::Char(terminalValue->at(0)), location, false);
         // This is the list of arguments we pass to the GAP AST algebra
         // function application.
         std::list<Fn_Arg::Base*> args;


### PR DESCRIPTION
Production rules in grammars can use two types of special terminal parser. The first is a terminal parser specialized to certain inputs, e.g. `CHAR` can be specialized to just accept a letter `A` like `CHAR('A')`. Yield of this terminal parser is (1, 1).

The second type of special terminal parser is a construct that not really parses parts of the input but is handy to inject parameters to algebra functions, like `foo(CONST_CHAR('x'), ...)`. One might use algebra function `foo` in different rules in the algebra with different constants, another rule could be `foo(CONST_CHAR('y'), ...)`. These terminal parser must have a yield size of (0, 0) as the do not advance in parsing inputs.

Currently, the yield of the `Fn_Arg::Const` was computed incorrectly, i.e. second type did get a non zero yield size. This PR shall fix this issue in preparation of proper summing yield sizes for outside grammar computation.