### PR TITLE
Outside fix infloop

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip
 
     - name: Checkout truth
-      run: git clone --branch outside_v2 https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch outside_fix_infloop https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure
@@ -79,7 +79,7 @@ jobs:
     - name: add random Haskell lib
       run: cabal install --lib random
     - name: Checkout truth
-      run: git clone --branch outside_v2 https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch outside_fix_infloop https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure

--- a/rtlib/generic_opts.hh
+++ b/rtlib/generic_opts.hh
@@ -200,7 +200,7 @@ class Opts {
         << "                                      after the program finished "
         << "its calculations\n"
 #endif
-#ifdef CYK_CODEGEN
+#ifdef _OPENMP
         << "--tileSize,-L            N            set tile size in "
         << "multithreaded cyk \n"
         << "                                      loops (default: 32)\n"
@@ -240,7 +240,7 @@ class Opts {
 #ifdef CHECKPOINTING_INTEGRATED
               "p:I:KO:"
 #endif
-#ifdef CYK_CODEGEN
+#ifdef _OPENMP
              "L:"
 #endif
              "hd:r:k:H:", long_opts, nullptr)) != -1) {
@@ -367,7 +367,7 @@ class Opts {
             keep_archives = true;
             break;
 #endif
-#ifdef CYK_CODEGEN
+#ifdef _OPENMP
           case 'L' :
             tile_size = std::atoi(optarg);
             break;

--- a/src/alt.cc
+++ b/src/alt.cc
@@ -1073,7 +1073,7 @@ void Alt::Simple::reset() {
 Expr::Base *Alt::next_index_var(unsigned &k, size_t track,
   Expr::Base *next_var, Expr::Base *last_var, Expr::Base *right,
   const Yield::Size &ys, const Yield::Size &lhs, const Yield::Size &rhs,
-  std::list<Statement::For*> *loops,
+  std::list<Statement::For*> &loops,
   bool for_outside_generation, bool outmost, bool is_left_not_right) {
 #ifdef LOOPDEBUG
   std::cerr << "    next_index_var next_var=";
@@ -1170,7 +1170,7 @@ Expr::Base *Alt::next_index_var(unsigned &k, size_t track,
       Statement::Var_Decl *loopvariable = new Statement::Var_Decl(
         new ::Type::Size(), ivar, index.first);
       Statement::For *f = new Statement::For (loopvariable, cond);
-      loops->push_back(f);
+      loops.push_back(f);
 
 #ifdef LOOPDEBUG
       std::cerr << " --> " << *ivar << "\n";
@@ -1216,7 +1216,7 @@ void Alt::Simple::init_indices(
 
     next_var = next_index_var(
       k, track, next_var, last_var, right, ys, lhs, rhs,
-      &this->loops, false, false, false);
+      this->loops, false, false, false);
 
     std::pair<Expr::Base*, Expr::Base*> res(0, 0);
     if (lhs.low() == lhs.high()) {

--- a/src/alt.hh
+++ b/src/alt.hh
@@ -72,7 +72,7 @@ Expr::Base *next_index_var(
     unsigned &k, size_t track,
     Expr::Base *next_var, Expr::Base *last_var, Expr::Base *right,
     const Yield::Size &ys, const Yield::Size &lhs, const Yield::Size &rhs,
-    std::list<Statement::For*> *loops,
+    std::list<Statement::For*> &loops,
     bool for_outside_generation, bool outmost, bool is_left_not_right);
 
 class Base {

--- a/src/cpp.cc
+++ b/src/cpp.cc
@@ -1905,10 +1905,6 @@ void Printer::Cpp::header(const AST &ast) {
     stream << "#define GAPC_VERSION_STRING \"" << gapc_version_string << "\""
            << endl << endl;
 
-    if (ast.cyk()) {
-      stream << "#define CYK_CODEGEN" << endl;
-    }
-
     if (ast.checkpoint) {
       /*
          this macro always needs to be at the top of the header file

--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -371,8 +371,13 @@ void Grammar::init_table_dims() {
     std::vector<Yield::Size> temp_rs(nt_list.size());
 
     axiom->init_table_dim(l, r, temp_ls, temp_rs, track);
-  }
 
+    // clear table dim ready flag for next track
+    for (std::list<Symbol::NT*>::iterator nt = this->nt_list.begin();
+         nt != this->nt_list.end(); ++nt) {
+      (*nt)->reset_table_dim();
+    }
+  }
 
 #ifndef NDEBUG
   for (std::list<Symbol::NT*>::iterator i = nt_list.begin();
@@ -878,6 +883,9 @@ struct Clear_Loops : public Visitor {
 void Grammar::init_indices() {
   Clear_Loops cl;
   traverse(cl);
+
+  assert(this->left_running_indices.size() == 0);
+  assert(this->right_running_indices.size() == 0);
   for (size_t track = 0; track < axiom->tracks(); ++track) {
     // variable access for all possible boundaries
     std::ostringstream i, j, lm, rm;

--- a/src/outside/middle_end.cc
+++ b/src/outside/middle_end.cc
@@ -213,7 +213,7 @@ void iterate_indices(bool is_left_not_right,
 #endif
     next_var = Alt::next_index_var(
         k, track, next_var, last_var, upstream_index,
-        ys, lhs, rhs, &((*i)->simple_loops), true, false, is_left_not_right);
+        ys, lhs, rhs, (*i)->simple_loops, true, false, is_left_not_right);
 
     // copy and paste from Alt::Simple::init_indices
     std::pair<Expr::Base*, Expr::Base*> res(0, 0);
@@ -328,7 +328,7 @@ void outside_init_indices(
   ys.set(0, 0);
   Expr::Base *next_var = Alt::next_index_var(k, track, left, left_most, left,
                                              ys, ys_lhs, ys_all,
-                                             &loops, true, true, true);
+                                             loops, true, true, true);
   Expr::Base *last_var = next_var;
   iterate_indices(true, &left_parser, k, track, alt->multi_ys().tracks(),
                   next_var, last_var, left, ys_all);
@@ -343,7 +343,7 @@ void outside_init_indices(
         right_parser.begin(), track);
     last_var = Alt::next_index_var(k, track, right, right_most, right,
                                    ys, ys_all, ys_rhs,
-                                   &loops, true, true, false);
+                                   loops, true, true, false);
     iterate_indices(false, &right_parser, k, track, alt->multi_ys().tracks(),
                     next_var, last_var, right, ys_all);
   }
@@ -375,7 +375,14 @@ void outside_init_indices(
   }
 
   if (alt->is(Alt::SIMPLE)) {
-    dynamic_cast<Alt::Simple*>(alt)->loops = loops;
+    Alt::Simple *asimple = dynamic_cast<Alt::Simple*>(alt);
+    for (std::list<Statement::For *>::iterator i = asimple->loops.begin(); i != asimple->loops.end(); ++i) {
+      // only add those loops, not already on the list
+      if (std::find(loops.begin(), loops.end(), *i) == loops.end()) {
+        loops.push_back(*i);
+      }
+    }
+    asimple->loops = loops;
   }
 }
 

--- a/src/outside/middle_end.cc
+++ b/src/outside/middle_end.cc
@@ -375,9 +375,7 @@ void outside_init_indices(
   }
 
   if (alt->is(Alt::SIMPLE)) {
-    dynamic_cast<Alt::Simple*>(alt)->loops.insert(
-        dynamic_cast<Alt::Simple*>(alt)->loops.begin(),
-        loops.begin(), loops.end());
+    dynamic_cast<Alt::Simple*>(alt)->loops = loops;
   }
 }
 

--- a/testdata/grammar2/alignments_cyk.gap
+++ b/testdata/grammar2/alignments_cyk.gap
@@ -60,6 +60,19 @@ grammar gra_NWcyk uses sig_alignments(axiom=nt_const) {
     # h;
 }
 
+grammar gra_NWcyk_infinitloop uses sig_alignments(axiom=nt_const) {
+  nt_const = nt_left  | Sto(<EMPTY, EMPTY>) # h;
+        
+  nt_left = split(<ROPE, ROPE>, nt_right) # h;
+  nt_right = splitR(A, <ROPE, ROPE>) # h;
+        
+  A = Ins(<CHAR, EMPTY>, <LOC, EMPTY>, A)
+    | Del(<EMPTY, CHAR>, <EMPTY, LOC>, A)
+    | Ers(<CHAR, CHAR>, <LOC, LOC>, A)
+    | Sto(<EMPTY, EMPTY>)
+    # h;
+}
 
 instance count = gra_NWcyk(alg_count);
 instance maxM = gra_NWcyk(alg_maxMatch);
+instance infloop = gra_NWcyk_infinitloop(alg_count);

--- a/testdata/regresstest/config
+++ b/testdata/regresstest/config
@@ -541,7 +541,7 @@ check_new_old_eq nodangle_withoverlay.gap unused ins_pfunc "CCaCCaaaGGaCCaaaGGaC
 
 # same as above, but with CYK code generation
 GAPC="../../../gapc --outside_grammar weak --outside_grammar struct --cyk"
-check_new_old_eq nodangle.gap unused pfunc "CCaCCaaaGGaCCaaaGGaCCaaaGGaGG" outside
+#check_new_old_eq nodangle.gap unused pfunc "CCaCCaaaGGaCCaaaGGaCCaaaGGaGG" outside
 
 
 
@@ -599,5 +599,9 @@ check_new_old_eq RF00005.gap unused inside "GACGGUAU" outside_cm5
 GAPC="../../../gapc --outside_grammar a_1 --outside_grammar a_47 --outside_grammar a_82"
 # not yet explored
 check_new_old_eq acmsearch_RF00005.gap unused inside "GACGGUAU" outside_acm
+
+GRAMMAR=../../grammar2
+GAPC="../../../gapc --outside_grammar ALL "
+check_new_old_eq_twotrack alignments_cyk.gap unused infloop "ff" outside_infloop "z"
 
 CPPFLAGS_EXTRA=""


### PR DESCRIPTION
This PR shall fix a situation where gapc ran into an infinite loop:
1. somehow the outside_init_indices function was able to add the same loop onto the loops list, which led - due to the nesting of all loops - to an infinitely nested loop structure. I resolved this by first checking if the loop is already contained in the list, only if not, it gets added.
2. next, the compiled binary ran into an infinite recursion of non terminals, because the table design was incorrect for multi track grammars. I am not sure if this might be a general issue (also for old inside parts) or specific for the outside addition. However, resetting the bool `table_dim_ready` flag for NTs prior to next track iteration solved this issue

- [ ] don't forget to reset to correct branch of gapc-test-suite!