### PR TITLE
escape CHAR('&') for plot-grammar

### DIFF
--- a/src/fn_arg.hh
+++ b/src/fn_arg.hh
@@ -136,6 +136,8 @@ class Base {
 
     virtual void print(std::ostream &s) = 0;
 
+    void to_dot(std::ostream &out);
+
     virtual bool choice_set() = 0;
 
  protected:

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -775,8 +775,11 @@ void Type::Base::to_dot(std::ostream &out) {
   std::ostringstream dtype_stream;
   this->put(dtype_stream);
   std::string dtype = dtype_stream.str();
-  replaceAll(dtype, std::string("<"), std::string("&lt;"));
-  replaceAll(dtype, std::string(">"), std::string("&gt;"));
+  replaceAll(dtype, "&",  "&amp;");
+  replaceAll(dtype, "\"", "&quot;");
+  replaceAll(dtype, "\'", "&apos;");
+  replaceAll(dtype, "<",  "&lt;");
+  replaceAll(dtype, ">",  "&gt;");
   out << dtype;
 }
 
@@ -786,6 +789,11 @@ void Fn_Arg::Base::to_dot(std::ostream &out) {
   std::ostringstream stream;
   this->print(stream);
   std::string rep = stream.str();
-  replaceAll(rep, std::string("&"), std::string("&amp;"));
+  replaceAll(rep, "&",  "&amp;");
+  replaceAll(rep, "\"", "&quot;");
+  replaceAll(rep, "\'", "&apos;");
+  replaceAll(rep, "<",  "&lt;");
+  replaceAll(rep, ">",  "&gt;");
+
   out << rep;
 }

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -287,7 +287,7 @@ unsigned int* Alt::Base::to_dot(unsigned int *nodeID, std::ostream &out,
         if (arg == simple->args.begin()) {
           out << "(";
         }
-        (*arg)->print(out);
+        (*arg)->to_dot(out);
         if (std::next(arg) != simple->args.end()) {
           out << ", ";
         } else {
@@ -780,3 +780,12 @@ void Type::Base::to_dot(std::ostream &out) {
   out << dtype;
 }
 
+// graphViz compatible text representation of Fn_Arg with parameters, e.g.
+// CHAR('&')
+void Fn_Arg::Base::to_dot(std::ostream &out) {
+  std::ostringstream stream;
+  this->print(stream);
+  std::string rep = stream.str();
+  replaceAll(rep, std::string("&"), std::string("&amp;"));
+  out << rep;
+}

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -776,8 +776,6 @@ void Type::Base::to_dot(std::ostream &out) {
   this->put(dtype_stream);
   std::string dtype = dtype_stream.str();
   replaceAll(dtype, "&",  "&amp;");
-  replaceAll(dtype, "\"", "&quot;");
-  replaceAll(dtype, "\'", "&apos;");
   replaceAll(dtype, "<",  "&lt;");
   replaceAll(dtype, ">",  "&gt;");
   out << dtype;
@@ -790,8 +788,6 @@ void Fn_Arg::Base::to_dot(std::ostream &out) {
   this->print(stream);
   std::string rep = stream.str();
   replaceAll(rep, "&",  "&amp;");
-  replaceAll(rep, "\"", "&quot;");
-  replaceAll(rep, "\'", "&apos;");
   replaceAll(rep, "<",  "&lt;");
   replaceAll(rep, ">",  "&gt;");
 


### PR DESCRIPTION
Properly escape `CHAR('&')` via `CHAR('&amp;')` for graphviz output to avoid e.g.
![image](https://github.com/jlab/gapc/assets/11960616/f0f91462-90e1-42f4-bb3a-1d419c54f8f0)
