### PR TITLE
Redefine grammar colors

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip
 
     - name: Checkout truth
-      run: git clone --branch redefine_grammar_colors https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure
@@ -83,7 +83,7 @@ jobs:
     - name: add base Haskell lib containers (prelude, Data.Map, Data.Map.Strict)
       run: cabal install --lib base
     - name: Checkout truth
-      run: git clone --branch redefine_grammar_colors https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip
 
     - name: Checkout truth
-      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch redefine_grammar_colors https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure
@@ -83,7 +83,7 @@ jobs:
     - name: add base Haskell lib containers (prelude, Data.Map, Data.Map.Strict)
       run: cabal install --lib base
     - name: Checkout truth
-      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch redefine_grammar_colors https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure

--- a/src/plot_grammar.cc
+++ b/src/plot_grammar.cc
@@ -21,22 +21,16 @@
 
 }}} */
 
+#include <vector>
+#include <list>
+#include <string>
 #include "alt.hh"
 #include "symbol.hh"
 #include "expr.hh"
 #include "const.hh"
 #include "fn_arg.hh"
 #include "fn_def.hh"
-
-static const char *COLOR_OVERLAY = "#cc5555";
-static const char *COLOR_INDICES = "#555555";
-static const char *COLOR_FILTER = "magenta";
-static const char *COLOR_TYPE = "orange";
-static const char *COLOR_TERMINAL = "blue";
-static const char *COLOR_ALGFCT = "green";
-static const char *COLOR_NONTERMINAL = "black";
-static const char *COLOR_BLOCK = "gray";
-static const char *COLOR_EVALFCT = "purple";
+#include "plot_grammar.hh"
 
 // a mechanism to properly indent dot code
 static int indent_depth = 0;

--- a/src/plot_grammar.hh
+++ b/src/plot_grammar.hh
@@ -1,0 +1,46 @@
+/* {{{
+
+    This file is part of gapc (GAPC - Grammars, Algebras, Products - Compiler;
+      a system to compile algebraic dynamic programming programs)
+
+    Copyright (C) 2008-2011  Georg Sauthoff
+         email: gsauthof@techfak.uni-bielefeld.de or gsauthof@sdf.lonestar.org
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+}}} */
+
+
+#ifndef SRC_PLOT_GRAMMAR_HH_
+#define SRC_PLOT_GRAMMAR_HH_
+
+
+/* color definitions for grammar plots as well as tikZ candidate trees.
+ * As tikZ's latex syntax requires an [HTML] parameter for color definitions,
+ * we cannot use mixed encoding (names & hex), which works well for graphViz,
+ * though.
+ */
+
+static const char * const COLOR_OVERLAY = "#cc5555";      // "brown"
+static const char * const COLOR_INDICES = "#555555";      // "light gray"
+static const char * const COLOR_FILTER = "#fc02fc";       // "magenta"
+static const char * const COLOR_TYPE = "#fca604";         // "orange"
+static const char * const COLOR_TERMINAL = "#0402fc";     // "blue"
+static const char * const COLOR_ALGFCT = "#14fe14";       // "green"
+static const char * const COLOR_NONTERMINAL = "#0c0a0c";  // "black";
+static const char * const COLOR_BLOCK = "#c4c2c4";        // "gray";
+static const char * const COLOR_EVALFCT = "#a42af4";      // "purple"
+
+
+#endif  // SRC_PLOT_GRAMMAR_HH_


### PR DESCRIPTION
This PR prepares tikz auto algebra generation as it exposes color definitions of plot-grammar via a header file. Furthermore, as our target language will be tikZ=latex, we can no longer use a mix of hex and named colors, thus converting every color to hex.