### PR TITLE
clear left/right running indices

### DIFF
--- a/src/grammar.cc
+++ b/src/grammar.cc
@@ -884,8 +884,8 @@ void Grammar::init_indices() {
   Clear_Loops cl;
   traverse(cl);
 
-  assert(this->left_running_indices.size() == 0);
-  assert(this->right_running_indices.size() == 0);
+  this->left_running_indices.clear();
+  this->right_running_indices.clear();
   for (size_t track = 0; track < axiom->tracks(); ++track) {
     // variable access for all possible boundaries
     std::ostringstream i, j, lm, rm;


### PR DESCRIPTION
the init_indices() function can be called multiple times, i.e. two times for backtraceing. The left/right_running_indices are not empty in the second traversal. Instead of asserting emptiness, we now simply clear both containers upfront.