### PR TITLE
Fix vector sparse

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -88,7 +88,7 @@ jobs:
     #- name: add base Haskell lib containers (prelude, Data.Map, Data.Map.Strict)
     #  run: cabal install --lib base
     - name: Checkout truth
-      run: git clone --branch migrate_osx14 https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v6
     - name: configure

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -94,7 +94,14 @@ jobs:
     - name: configure
       run: ./configure --prefix $GITHUB_WORKSPACE
     - name: patch configuration for OSX
-      run: gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
+      run: |
+        BOOST_PREFIX=$(brew --prefix boost)
+        gsed -E "s|^BOOST_CPPFLAGS = .+$|BOOST_CPPFLAGS = -I${BOOST_PREFIX}/include|" -i config.mf
+        gsed -E "s|^BOOST_LDFLAGS = .+$|BOOST_LDFLAGS = -L${BOOST_PREFIX}/lib|" -i config.mf
+        gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf
+        gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
+        gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
+        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -94,7 +94,11 @@ jobs:
     - name: configure
       run: ./configure --prefix $GITHUB_WORKSPACE --with-boost=/opt/homebrew/Cellar/boost/1.90.0_1/
     - name: patch configuration for OSX
-      run: gsed -E "s|^YACC = .+$|YACC = /opt/homebrew/opt/bison/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
+      run: |
+        gsed -E "s|^YACC = .+$|YACC = /opt/homebrew/opt/bison/bin/bison|" -i config.mf
+        gsed -E "s|^SED = .+$|SED = /opt/homebrew/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
+        gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
+        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -92,7 +92,7 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost /opt/homebrew/Cellar/boost/1.90.0_1
+      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost=/opt/homebrew/Cellar/boost/1.90.0_1/
     - name: patch configuration for OSX
       run: gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,7 +22,7 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         # as of 21st Sep 2021, ubuntu-16.04 is no longer supported by github actions: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/
         # 18.04 burnout: https://github.com/actions/runner-images/issues/6002
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Update apt
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-        os: [macos-13]
+        os: [macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install dependencies

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout truth
       run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: configure
       run: ./configure --prefix $GITHUB_WORKSPACE
     - name: make
@@ -90,7 +90,7 @@ jobs:
     - name: Checkout truth
       run: git clone --branch migrate_osx14 https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: configure
       run: ./configure --prefix $GITHUB_WORKSPACE --with-boost=/opt/homebrew/opt/boost/
     - name: patch configuration for OSX
@@ -123,8 +123,8 @@ jobs:
         name: test-mod_outside_results
         path: ./testdata/modtest/temp
 
-    #- name: test-regress
-    #  run: make test-regress TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
+    - name: test-regress
+      run: make test-regress TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
     - name: test-ambiguity
       run: make test-ambiguity TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
     - name: test-unit
@@ -144,7 +144,7 @@ jobs:
       run: sudo apt-get update
     - name: Install dependencies
       run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip python3-biopython
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: configure
       run: ./configure
     - name: make
@@ -171,7 +171,7 @@ jobs:
   cpplint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v4
     - run: pip install cpplint
     - run: cpplint --recursive --counting 'detailed' --filter="-runtime/references,-build/include_subdir" --extensions=cc,hh src/ rtlib/

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost $(brew --prefix boost)
+      run: ./configure --prefix $GITHUB_WORKSPACE
     - name: make
       run: make -j 2
     - name: make install
@@ -92,7 +92,7 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE
+      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost $(brew --prefix boost)
     - name: patch configuration for OSX
       run: gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -99,7 +99,7 @@ jobs:
         gsed -E "s|^SED = .+$|SED = /opt/homebrew/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
         gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
         gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 -I\/opt\/homebrew\/opt\/gmp\/include /" -i config.mf
-        gsed -E "s/\$\(LDFLAGS_EXTRA\) \\/\$\(LDFLAGS_EXTRA\) -L/opt/homebrew/opt/gmp/lib \\/" -i config.mf
+        gsed -E 's|\$\(LDFLAGS_EXTRA\) \\|\$\(LDFLAGS_EXTRA\) -L/opt/homebrew/opt/gmp/lib \\|' -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -92,7 +92,7 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost $(brew --prefix boost)
+      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost /opt/homebrew/Cellar/boost/1.90.0_1
     - name: patch configuration for OSX
       run: gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -91,8 +91,6 @@ jobs:
       run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
-    - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE
     - name: patch configuration for OSX
       run: |
         BOOST_PREFIX=$(brew --prefix boost)
@@ -102,6 +100,8 @@ jobs:
         gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
         gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
         gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
+    - name: configure
+      run: ./configure --prefix $GITHUB_WORKSPACE
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE
+      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost $(brew --prefix boost)
     - name: make
       run: make -j 2
     - name: make install
@@ -91,17 +91,10 @@ jobs:
       run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
-    - name: patch configuration for OSX
-      run: |
-        BOOST_PREFIX=$(brew --prefix boost)
-        gsed -E "s|^BOOST_CPPFLAGS = .+$|BOOST_CPPFLAGS = -I${BOOST_PREFIX}/include|" -i config.mf
-        gsed -E "s|^BOOST_LDFLAGS = .+$|BOOST_LDFLAGS = -L${BOOST_PREFIX}/lib|" -i config.mf
-        gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf
-        gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
-        gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
-        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: configure
       run: ./configure --prefix $GITHUB_WORKSPACE
+    - name: patch configuration for OSX
+      run: gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -88,7 +88,7 @@ jobs:
     #- name: add base Haskell lib containers (prelude, Data.Map, Data.Map.Strict)
     #  run: cabal install --lib base
     - name: Checkout truth
-      run: git clone --branch master https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
+      run: git clone --branch migrate_osx14 https://github.com/jlab/gapc-test-suite.git $GITHUB_WORKSPACE/../gapc-test-suite
 
     - uses: actions/checkout@v3
     - name: configure

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -123,8 +123,8 @@ jobs:
         name: test-mod_outside_results
         path: ./testdata/modtest/temp
 
-    - name: test-regress
-      run: make test-regress TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
+    #- name: test-regress
+    #  run: make test-regress TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
     - name: test-ambiguity
       run: make test-ambiguity TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
     - name: test-unit

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: test-mod
       run: make test-mod TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth TRUTH_SUFFIX=_osx
-    - name: Export test results
+    - name: Export test-mod results
       if: failure()
       uses: actions/upload-artifact@v7
       with:
@@ -115,6 +115,13 @@ jobs:
 
     - name: test-mod_outside
       run: make -j 2 test-mod_outside TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth TRUTH_SUFFIX=_osx
+    - name: Export test-mod_outside results
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-mod_outside_results
+        path: ./testdata/modtest/temp
+
     - name: test-regress
       run: make test-regress TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth
     - name: test-ambiguity

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -75,12 +75,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install dependencies
-      run: brew install bison@3.8 cmake boost gsl gnu-sed libomp gmp cabal-install ghc
-    - name: pioritize bison3.8
+      run: brew install bison cmake boost gsl gnu-sed libomp gmp cabal-install ghc
+    - name: pioritize homebrew bison
       # macos-13 has also installed a quite old bison2.3 version and it is found first according
       # to default PATH settings. Thus, configure.ac will test the wrong version and NOT set
       # BISONNEW as a compiler flag (see configure.ac)
-      run: echo "PATH=/usr/local/opt/bison@3.8/bin:$PATH" >> $GITHUB_ENV
+      run: echo "PATH=/opt/homebrew/opt/bison/bin:$PATH" >> $GITHUB_ENV
     - name: update cabal
       run: cabal update
     - name: add random Haskell lib
@@ -94,7 +94,7 @@ jobs:
     - name: configure
       run: ./configure --prefix $GITHUB_WORKSPACE --with-boost=/opt/homebrew/Cellar/boost/1.90.0_1/
     - name: patch configuration for OSX
-      run: gsed -E "s|^YACC = .+$|YACC = /usr/local/opt/bison@3.8/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
+      run: gsed -E "s|^YACC = .+$|YACC = /opt/homebrew/opt/bison/bin/bison|" -i config.mf && gsed -E "s|^SED = .+$|SED = /usr/local/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf && gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf && gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -106,6 +106,13 @@ jobs:
 
     - name: test-mod
       run: make test-mod TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth TRUTH_SUFFIX=_osx
+    - name: Export test results
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-mod_results
+        path: ./testdata/modtest/temp
+
     - name: test-mod_outside
       run: make -j 2 test-mod_outside TRUTH_DIR=$GITHUB_WORKSPACE/../gapc-test-suite/Truth TRUTH_SUFFIX=_osx
     - name: test-regress

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -92,13 +92,14 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: configure
-      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost=/opt/homebrew/Cellar/boost/1.90.0_1/
+      run: ./configure --prefix $GITHUB_WORKSPACE --with-boost=/opt/homebrew/opt/boost/
     - name: patch configuration for OSX
       run: |
         gsed -E "s|^YACC = .+$|YACC = /opt/homebrew/opt/bison/bin/bison|" -i config.mf
         gsed -E "s|^SED = .+$|SED = /opt/homebrew/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
         gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
-        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 /" -i config.mf
+        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 -I\/opt\/homebrew\/opt\/gmp\/include /" -i config.mf
+        gsed -E "s/\$\(LDFLAGS_EXTRA\) \\/\$\(LDFLAGS_EXTRA\) -L/opt/homebrew/opt/gmp/lib \\/" -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -98,8 +98,8 @@ jobs:
         gsed -E "s|^YACC = .+$|YACC = /opt/homebrew/opt/bison/bin/bison|" -i config.mf
         gsed -E "s|^SED = .+$|SED = /opt/homebrew/opt/gnu-sed/libexec/gnubin/sed|" -i config.mf
         gsed -E "s/ -D_XOPEN_SOURCE=500 / /" -i config.mf
-        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 -I\/opt\/homebrew\/opt\/gmp\/include /" -i config.mf
-        gsed -E 's|\$\(LDFLAGS_EXTRA\) \\|\$\(LDFLAGS_EXTRA\) -L/opt/homebrew/opt/gmp/lib \\|' -i config.mf
+        gsed -E "s/ -std=c\+\+17 / -std=c\+\+11 -I\/opt\/homebrew\/opt\/gmp\/include -I\/opt\/homebrew\/opt\/gsl\/include /" -i config.mf
+        gsed -E 's|\$\(LDFLAGS_EXTRA\) \\|\$\(LDFLAGS_EXTRA\) -L/opt/homebrew/opt/gmp/lib -L/opt/homebrew/opt/gsl/lib \\|' -i config.mf
     - name: make
       run: make -j 3
     - name: make install

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  | |_) |  __/ | | | | | | | (_| | | | | \__ \ | |__| |/ ____ \| |     
  |____/ \___|_|_|_| |_| |_|\__,_|_| |_| |___/  \_____/_/    \_\_|     
 ```                                                                      
-                                                                  
+                                                                    
 ## Dependencies
 
 Bellman's GAP was tested on the following dependencies.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  | |_) |  __/ | | | | | | | (_| | | | | \__ \ | |__| |/ ____ \| |     
  |____/ \___|_|_|_| |_| |_|\__,_|_| |_| |___/  \_____/_/    \_\_|     
 ```                                                                      
-                                                                    
+                                                                  
 ## Dependencies
 
 Bellman's GAP was tested on the following dependencies.

--- a/rtlib/adp.hh
+++ b/rtlib/adp.hh
@@ -26,8 +26,7 @@
 #define RTLIB_ADP_HH_
 
 #include <algorithm>
-// needed for uint64_t (Integer ...)
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #include "empty.hh"
 #include "algebra.hh"

--- a/rtlib/bigint.hh
+++ b/rtlib/bigint.hh
@@ -33,7 +33,7 @@ typedef mpz_class BigInt;
 
 #else
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 typedef uint64_t BigInt;
 

--- a/rtlib/bitops.hh
+++ b/rtlib/bitops.hh
@@ -26,7 +26,7 @@
 
 #include <cassert>
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 template <typename T>
 int

--- a/rtlib/hashtng.hh
+++ b/rtlib/hashtng.hh
@@ -31,7 +31,7 @@
 #include <vector>
 #include <algorithm>
 #include <utility>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 
 #include "bitops.hh"

--- a/rtlib/list.hh
+++ b/rtlib/list.hh
@@ -40,8 +40,7 @@
 #include <utility>
 // #include <set>
 
-// tr1 has it
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 
 #include "empty.hh"

--- a/rtlib/multipool.hh
+++ b/rtlib/multipool.hh
@@ -30,8 +30,7 @@
 
 #include <vector>
 
-// tr1 has it
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #include "map_pool.hh"
 

--- a/rtlib/pool.hh
+++ b/rtlib/pool.hh
@@ -28,8 +28,7 @@
 #include <cassert>
 #include <cstdlib>
 
-// tr1 has it
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #include "map_pool.hh"
 

--- a/rtlib/rope.hh
+++ b/rtlib/rope.hh
@@ -33,7 +33,7 @@
 #include <sstream>
 
 #include <string>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <boost/algorithm/string/replace.hpp>
 
 #include "../rtlib/cstr.h"

--- a/rtlib/shape.hh
+++ b/rtlib/shape.hh
@@ -35,7 +35,7 @@
 #include <algorithm>
 #include <utility>
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #include "shape_alph.hh"
 #include "bitops.hh"

--- a/rtlib/string.hh
+++ b/rtlib/string.hh
@@ -34,8 +34,6 @@
 #include <vector>
 #include <cstdint>
 
-#include <cstdint>
-
 // FIXME profile this
 #include "pool.hh"
 

--- a/rtlib/string.hh
+++ b/rtlib/string.hh
@@ -34,8 +34,7 @@
 #include <vector>
 #include <cstdint>
 
-// tr1 has it
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 // FIXME profile this
 #include "pool.hh"

--- a/rtlib/vector_sparse.hh
+++ b/rtlib/vector_sparse.hh
@@ -116,7 +116,7 @@ class Stapel {
 
   T &pop() {
     assert(top_);
-    return array[top_--];
+    return array[--top_];
   }
 
   T &top() {
@@ -285,7 +285,7 @@ template <typename T, typename U = size_t> class Vector_Sparse {
    public:
     typedef T value_type;
     typedef std::random_access_iterator_tag iterator_category;
-    typedef U difference_type;
+    typedef std::ptrdiff_t difference_type;
     typedef T* pointer;
     typedef T& reference;
 
@@ -343,7 +343,21 @@ template <typename T, typename U = size_t> class Vector_Sparse {
 
     Iterator operator+=(const difference_type &other) {
       i += other;
-      return Iterator(v, i);
+      return *this;
+    }
+
+    Iterator& operator-=(difference_type other) {
+      i -= other;
+      return *this;
+    }
+    reference operator[](difference_type n) {
+      return v(*(i + n));
+    }
+    pointer operator->() {
+      return &v(*i);
+    }
+    const reference operator*() const {
+      return v(*i);
     }
 
     bool operator>(const Iterator &other) const {

--- a/src/runtime.hh
+++ b/src/runtime.hh
@@ -32,8 +32,7 @@
 #include "yieldsize.hh"
 #include "table.hh"
 
-// tr1 has it
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 
 #ifndef UINT32_MAX

--- a/src/runtime.hh
+++ b/src/runtime.hh
@@ -28,12 +28,10 @@
 #include <iostream>
 #include <vector>
 #include <cassert>
+#include <cstdint>
 
 #include "yieldsize.hh"
 #include "table.hh"
-
-#include <cstdint>
-
 
 #ifndef UINT32_MAX
 #define UINT32_MAX 4294967295U

--- a/src/yieldsize.hh
+++ b/src/yieldsize.hh
@@ -30,8 +30,7 @@
 #include <vector>
 #include <list>
 
-// tr1 has it
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class Filter;
 

--- a/testdata/sandbox/accu.cc
+++ b/testdata/sandbox/accu.cc
@@ -1,5 +1,5 @@
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>

--- a/testdata/sandbox/limits.cc
+++ b/testdata/sandbox/limits.cc
@@ -1,6 +1,6 @@
 
 #include <cassert>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #define UINT32_MAX 4294967295U
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR is for maintenance. Triggered by the migration to "Debian GNU/Linux 13 (trixie)", Elena found that `boost/cstdint.hpp` is no longer available. This is due to the fact that functionality was meanwhile integrated into C libs; thus we now can `#include <cstdint>` instead of `#include "boost/cstdint.hpp"`.

I furthermore found that ubuntu 20.04 and osx13 are no longer available for github actions and thus dropped 20.04 and switched from osx13 to osx14. This in turn revealed some issues with include/lib paths for the osx runner AND a bug in the `sparse_vector` implementation. I used claude to find a workaround but don't fully understand if this really fixed the bug - at least it does not lead to failures in our tests AND passed compilation in osx14 :-)

Note that the usual mod-tests failed, when compared to truth - as they often do when things changes due to heuristic aspects in the tabulation algorithm. There are still some osx14 tests failing with regards to checkpointing - an issue that I never fully resolved :-/ Please ignore for now.